### PR TITLE
Fixed bug in DTEDRasterReader where AVList was assumed non-null

### DIFF
--- a/src/gov/nasa/worldwind/data/DTEDRasterReader.java
+++ b/src/gov/nasa/worldwind/data/DTEDRasterReader.java
@@ -43,6 +43,11 @@ public class DTEDRasterReader extends AbstractDataRasterReader
             return false;
         }
 
+        if (null == params)
+        {
+            params = new AVListImpl();
+        }
+
         // Assume that a proper suffix reliably identifies a DTED file. Otherwise the file will have to be loaded
         // to determine that, and there are often tens of thousands of DTED files, which causes raster server start-up
         // times to be excessive.

--- a/src/gov/nasa/worldwind/data/DTEDRasterReader.java
+++ b/src/gov/nasa/worldwind/data/DTEDRasterReader.java
@@ -43,15 +43,10 @@ public class DTEDRasterReader extends AbstractDataRasterReader
             return false;
         }
 
-        if (null == params)
-        {
-            params = new AVListImpl();
-        }
-
         // Assume that a proper suffix reliably identifies a DTED file. Otherwise the file will have to be loaded
         // to determine that, and there are often tens of thousands of DTED files, which causes raster server start-up
         // times to be excessive.
-        if (this.canReadSuffix(source))
+        if (this.canReadSuffix(source) && null != params)
         {
             params.setValue(AVKey.PIXEL_FORMAT, AVKey.ELEVATION); // we know that DTED is elevation data
             return true;

--- a/src/gov/nasa/worldwind/data/DTEDRasterReader.java
+++ b/src/gov/nasa/worldwind/data/DTEDRasterReader.java
@@ -43,10 +43,15 @@ public class DTEDRasterReader extends AbstractDataRasterReader
             return false;
         }
 
+        if (null == params)
+        {
+            params = new AVListImpl();
+        }
+
         // Assume that a proper suffix reliably identifies a DTED file. Otherwise the file will have to be loaded
         // to determine that, and there are often tens of thousands of DTED files, which causes raster server start-up
         // times to be excessive.
-        if (this.canReadSuffix(source) && null != params)
+        if (this.canReadSuffix(source))
         {
             params.setValue(AVKey.PIXEL_FORMAT, AVKey.ELEVATION); // we know that DTED is elevation data
             return true;


### PR DESCRIPTION
In DTEDRasterReader added check for null AVList before trying to use it, if null create a new empty AVListImpl.