### PR TITLE
This small fix solves a NPE in cases in which a look&feel has been set.

### DIFF
--- a/src/gov/nasa/worldwind/awt/WorldWindowGLJPanel.java
+++ b/src/gov/nasa/worldwind/awt/WorldWindowGLJPanel.java
@@ -367,7 +367,7 @@ public class WorldWindowGLJPanel extends GLJPanel implements WorldWindow, Proper
     public synchronized void addPropertyChangeListener(PropertyChangeListener listener)
     {
         super.addPropertyChangeListener(listener);
-        if(wwd!=null)
+        if (wwd != null) // defensive condition for NPE that happens when (for example) setting a swing look/feel
             this.wwd.addPropertyChangeListener(listener);
     }
 

--- a/src/gov/nasa/worldwind/awt/WorldWindowGLJPanel.java
+++ b/src/gov/nasa/worldwind/awt/WorldWindowGLJPanel.java
@@ -367,7 +367,8 @@ public class WorldWindowGLJPanel extends GLJPanel implements WorldWindow, Proper
     public synchronized void addPropertyChangeListener(PropertyChangeListener listener)
     {
         super.addPropertyChangeListener(listener);
-        this.wwd.addPropertyChangeListener(listener);
+        if(wwd!=null)
+            this.wwd.addPropertyChangeListener(listener);
     }
 
     @Override


### PR DESCRIPTION
This small fix solves a NPE in cases in which a look&feel has been set.

I am not sure if this is enough though. It seems to work properly.

`
java.lang.NullPointerException
	at gov.nasa.worldwind.awt.WorldWindowGLJPanel.addPropertyChangeListener(WorldWindowGLJPanel.java:371)
	at javax.swing.plaf.synth.SynthPanelUI.installListeners(SynthPanelUI.java:83)
	at javax.swing.plaf.synth.SynthPanelUI.installUI(SynthPanelUI.java:63)
	at javax.swing.JComponent.setUI(JComponent.java:666)
	at javax.swing.JPanel.setUI(JPanel.java:153)
	at javax.swing.JPanel.updateUI(JPanel.java:126)
	at javax.swing.JPanel.<init>(JPanel.java:86)
	at javax.swing.JPanel.<init>(JPanel.java:109)
	at javax.swing.JPanel.<init>(JPanel.java:117)
	at javax.media.opengl.awt.GLJPanel.<init>(GLJPanel.java:349)
	at gov.nasa.worldwind.awt.WorldWindowGLJPanel.<init>(WorldWindowGLJPanel.java:63)
`