### PR TITLE
Removed superfluous override of WMS_VERSION

### DIFF
--- a/src/gov/nasa/worldwind/wms/WMSTiledImageLayer.java
+++ b/src/gov/nasa/worldwind/wms/WMSTiledImageLayer.java
@@ -145,7 +145,6 @@ public class WMSTiledImageLayer extends BasicTiledImageLayer
         setFallbacks(params);
 
         // Setup WMS URL builder.
-        params.setValue(AVKey.WMS_VERSION, caps.getVersion());
         params.setValue(AVKey.TILE_URL_BUILDER, new URLBuilder(params));
         // Setup default WMS tiled image layer behaviors.
         params.setValue(AVKey.USE_TRANSPARENT_TEXTURES, true);


### PR DESCRIPTION
The parameter WMS_VERSION is already read from configuration and set in
the params varable. To overwrite it here will only make it impossible to
change by configuration.
