### PR TITLE
Text layer

### DIFF
--- a/src/gov/nasa/worldwind/formats/vpf/VPFLayer.java
+++ b/src/gov/nasa/worldwind/formats/vpf/VPFLayer.java
@@ -40,7 +40,7 @@ public class VPFLayer extends AbstractLayer
     protected ArrayList<Renderable> renderableObjects = new ArrayList<Renderable>();
 
     // Renderers
-    protected GeographicTextRenderer textRenderer = new GeographicTextRenderer();
+    protected BasicGeographicTextRenderer textRenderer = new BasicGeographicTextRenderer();
     protected VPFSymbolSupport symbolSupport = new VPFSymbolSupport(GeoSymConstants.GEOSYM, "image/png");
 
     // Threaded requests

--- a/src/gov/nasa/worldwind/layers/GraticuleSupport.java
+++ b/src/gov/nasa/worldwind/layers/GraticuleSupport.java
@@ -60,7 +60,7 @@ public class GraticuleSupport
     private Map<String, GraticuleRenderingParams> namedParams = new HashMap<String, GraticuleRenderingParams>();
     private Map<String, ShapeAttributes> namedShapeAttributes = new HashMap<String, ShapeAttributes>();
     private AVList defaultParams;
-    private GeographicTextRenderer textRenderer = new GeographicTextRenderer();
+    private BasicGeographicTextRenderer textRenderer = new BasicGeographicTextRenderer();
 
     public GraticuleSupport()
     {

--- a/src/gov/nasa/worldwind/layers/TextLayer.java
+++ b/src/gov/nasa/worldwind/layers/TextLayer.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (C) 2014, United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration,
+ * All Rights Reserved.
+ */
+package gov.nasa.worldwind.layers;
+
+import gov.nasa.worldwind.render.BasicGeographicTextRenderer;
+import gov.nasa.worldwind.render.DrawContext;
+import gov.nasa.worldwind.render.GeographicText;
+import gov.nasa.worldwind.render.GeographicTextRenderer;
+import gov.nasa.worldwind.util.Logging;
+
+import java.util.Collection;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * Layer to support objects of type {@link GeographicText}
+ * 
+ * @author Bruno Spyckerelle
+ * @version $Id$
+ */
+public class TextLayer extends AbstractLayer
+{
+    protected GeographicTextRenderer textRenderer;
+    protected Collection<GeographicText> geographicTexts;
+
+    public TextLayer()
+    {
+        this.textRenderer = new BasicGeographicTextRenderer();
+        this.geographicTexts = new ConcurrentLinkedQueue<GeographicText>();
+    }
+    
+    public GeographicTextRenderer getGeographicTextRenderer()
+    {
+        return this.textRenderer;
+    }
+    
+    public void setGeographicTextRenderer(GeographicTextRenderer textRenderer)
+    {
+        this.textRenderer = textRenderer;
+    }
+
+    /**
+     * Adds the specified <code>text</code> to this layer's internal collection.
+     * @param text {@link GeographicText} to add.
+     * @throws IllegalArgumentException If <code>text</code> is null.
+     */
+    public void addGeographicText(GeographicText text)
+    {
+        if (text == null)
+        {
+            String msg = "nullValue.GeographicTextIsNull";
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+        this.geographicTexts.add(text);
+    }
+
+    public void addGeographicTexts(Iterable<? extends GeographicText> texts)
+    {
+        if (texts == null)
+        {
+            String msg = Logging.getMessage("nullValue.IterableIsNull");
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+        for (GeographicText text : texts)
+        {
+            if (text != null)
+            {
+                this.geographicTexts.add(text);
+            }
+        }
+    }
+
+    public void removeGeographicText(GeographicText text)
+    {
+        if (text == null)
+        {
+            String msg = "nullValue.GeographicTextIsNull";
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+        this.geographicTexts.remove(text);
+    }
+    
+    public void removeGeographicTexts(Iterable<? extends GeographicText> texts)
+    {
+        if (texts == null)
+        {
+            String msg = Logging.getMessage("nullValue.IterableIsNull");
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+        for (GeographicText text : texts)
+        {
+            if (text != null)
+            {
+                this.geographicTexts.remove(text);
+            }
+        }
+    }
+
+    public void removeAllGeographicTexts()
+    {
+        this.geographicTexts.clear();
+    }
+
+    public Iterable<GeographicText> getActiveGeographicTexts()
+    {
+        return this.geographicTexts;
+    }
+
+    @Override
+    protected void doRender(DrawContext dc)
+    {
+        this.textRenderer.render(dc, getActiveGeographicTexts());
+    }
+}

--- a/src/gov/nasa/worldwind/render/BasicGeographicTextRenderer.java
+++ b/src/gov/nasa/worldwind/render/BasicGeographicTextRenderer.java
@@ -25,7 +25,7 @@ import java.util.*;
  * @author dcollins
  * @version $Id: GeographicTextRenderer.java 2392 2014-10-20 20:02:44Z tgaskins $
  */
-public class BasicGeographicTextRenderer
+public class BasicGeographicTextRenderer implements GeographicTextRenderer
 {
     private TextRenderer lastTextRenderer = null;
     private final GLU glu = new GLUgl2();
@@ -195,7 +195,7 @@ public class BasicGeographicTextRenderer
         this.distanceMinOpacity = opacity;
     }
 
-    public void render(DrawContext dc, Iterable<GeographicText> text)
+    public void render(DrawContext dc, Iterable<? extends GeographicText> text)
     {
         this.drawMany(dc, text);
     }
@@ -208,7 +208,7 @@ public class BasicGeographicTextRenderer
         this.drawOne(dc, text, textPoint);
     }
 
-    private void drawMany(DrawContext dc, Iterable<GeographicText> textIterable)
+    private void drawMany(DrawContext dc, Iterable<? extends GeographicText> textIterable)
     {
         if (dc == null)
         {
@@ -230,7 +230,7 @@ public class BasicGeographicTextRenderer
         if (geos == null)
             return;
 
-        Iterator<GeographicText> iterator = textIterable.iterator();
+        Iterator<? extends GeographicText> iterator = textIterable.iterator();
         if (!iterator.hasNext())
             return;
 

--- a/src/gov/nasa/worldwind/render/BasicGeographicTextRenderer.java
+++ b/src/gov/nasa/worldwind/render/BasicGeographicTextRenderer.java
@@ -25,7 +25,7 @@ import java.util.*;
  * @author dcollins
  * @version $Id: GeographicTextRenderer.java 2392 2014-10-20 20:02:44Z tgaskins $
  */
-public class GeographicTextRenderer
+public class BasicGeographicTextRenderer
 {
     private TextRenderer lastTextRenderer = null;
     private final GLU glu = new GLUgl2();
@@ -45,7 +45,7 @@ public class GeographicTextRenderer
 
     private boolean hasJOGLv111Bug = false;
 
-    public GeographicTextRenderer()
+    public BasicGeographicTextRenderer()
     {
     }
 
@@ -369,14 +369,14 @@ public class GeographicTextRenderer
             return this.eyeDistance;
         }
 
-        private GeographicTextRenderer getRenderer()
+        private BasicGeographicTextRenderer getRenderer()
         {
-            return GeographicTextRenderer.this;
+            return BasicGeographicTextRenderer.this;
         }
 
         public void render(DrawContext dc)
         {
-            GeographicTextRenderer.this.beginRendering(dc);
+            BasicGeographicTextRenderer.this.beginRendering(dc);
             try
             {
                 if (cullText)
@@ -389,7 +389,7 @@ public class GeographicTextRenderer
                     while (nextItem != null && nextItem instanceof OrderedText)
                     {
                         OrderedText ot = (OrderedText) nextItem;
-                        if (ot.getRenderer() != GeographicTextRenderer.this)
+                        if (ot.getRenderer() != BasicGeographicTextRenderer.this)
                             break;
 
                         textList.add(ot);
@@ -402,14 +402,14 @@ public class GeographicTextRenderer
                     ArrayList<Rectangle2D> textBounds = new ArrayList<Rectangle2D>();
                     for (OrderedText ot : textList)
                     {
-                        double[] scaleAndOpacity = GeographicTextRenderer.this.computeDistanceScaleAndOpacity(dc, ot);
-                        Rectangle2D newBounds = GeographicTextRenderer.this.computeTextBounds(dc, ot,
+                        double[] scaleAndOpacity = BasicGeographicTextRenderer.this.computeDistanceScaleAndOpacity(dc, ot);
+                        Rectangle2D newBounds = BasicGeographicTextRenderer.this.computeTextBounds(dc, ot,
                             scaleAndOpacity[0]);
                         if (newBounds == null)
                             continue;
 
                         boolean overlap = false;
-                        newBounds = GeographicTextRenderer.this.computeExpandedBounds(newBounds, cullTextMargin);
+                        newBounds = BasicGeographicTextRenderer.this.computeExpandedBounds(newBounds, cullTextMargin);
                         for (Rectangle2D rect : textBounds)
                         {
                             if (rect.intersects(newBounds))
@@ -419,24 +419,24 @@ public class GeographicTextRenderer
                         if (!overlap)
                         {
                             textBounds.add(newBounds);
-                            GeographicTextRenderer.this.drawText(dc, ot, scaleAndOpacity[0], scaleAndOpacity[1]);
+                            BasicGeographicTextRenderer.this.drawText(dc, ot, scaleAndOpacity[0], scaleAndOpacity[1]);
                         }
                     }
                 }
                 else //just draw each label
                 {
-                    double[] scaleAndOpacity = GeographicTextRenderer.this.computeDistanceScaleAndOpacity(dc, this);
-                    GeographicTextRenderer.this.drawText(dc, this, scaleAndOpacity[0], scaleAndOpacity[1]);
+                    double[] scaleAndOpacity = BasicGeographicTextRenderer.this.computeDistanceScaleAndOpacity(dc, this);
+                    BasicGeographicTextRenderer.this.drawText(dc, this, scaleAndOpacity[0], scaleAndOpacity[1]);
                     // Draw as many as we can in a batch to save ogl state switching.
                     Object nextItem = dc.peekOrderedRenderables();
                     while (nextItem != null && nextItem instanceof OrderedText)
                     {
                         OrderedText ot = (OrderedText) nextItem;
-                        if (ot.getRenderer() != GeographicTextRenderer.this)
+                        if (ot.getRenderer() != BasicGeographicTextRenderer.this)
                             break;
 
-                        scaleAndOpacity = GeographicTextRenderer.this.computeDistanceScaleAndOpacity(dc, ot);
-                        GeographicTextRenderer.this.drawText(dc, ot, scaleAndOpacity[0], scaleAndOpacity[1]);
+                        scaleAndOpacity = BasicGeographicTextRenderer.this.computeDistanceScaleAndOpacity(dc, ot);
+                        BasicGeographicTextRenderer.this.drawText(dc, ot, scaleAndOpacity[0], scaleAndOpacity[1]);
                         dc.pollOrderedRenderables(); // take it off the queue
                         nextItem = dc.peekOrderedRenderables();
                     }
@@ -452,7 +452,7 @@ public class GeographicTextRenderer
             }
             finally
             {
-                GeographicTextRenderer.this.endRendering(dc);
+                BasicGeographicTextRenderer.this.endRendering(dc);
             }
         }
 

--- a/src/gov/nasa/worldwind/render/DeclutteringTextRenderer.java
+++ b/src/gov/nasa/worldwind/render/DeclutteringTextRenderer.java
@@ -27,7 +27,7 @@ import java.util.Iterator;
  * @author tag
  * @version $Id: DeclutteringTextRenderer.java 2392 2014-10-20 20:02:44Z tgaskins $
  */
-public class DeclutteringTextRenderer
+public class DeclutteringTextRenderer implements GeographicTextRenderer
 {
     protected static final Font DEFAULT_FONT = Font.decode("Arial-PLAIN-12");
     protected static final Color DEFAULT_COLOR = Color.white;

--- a/src/gov/nasa/worldwind/render/DeclutteringTextRenderer.java
+++ b/src/gov/nasa/worldwind/render/DeclutteringTextRenderer.java
@@ -6,6 +6,7 @@
 
 package gov.nasa.worldwind.render;
 
+import gov.nasa.worldwind.avlist.AVKey;
 import gov.nasa.worldwind.geom.*;
 import gov.nasa.worldwind.globes.Globe2D;
 import gov.nasa.worldwind.terrain.SectorGeometryList;
@@ -32,6 +33,8 @@ public class DeclutteringTextRenderer
     protected static final Color DEFAULT_COLOR = Color.white;
 
     protected final GLU glu = new GLUgl2();
+    
+    private String effect = AVKey.TEXT_EFFECT_SHADOW;
 
     // Flag indicating a JOGL text rendering problem. Set to avoid continual exception logging.
     protected boolean hasJOGLv111Bug = false;
@@ -39,6 +42,35 @@ public class DeclutteringTextRenderer
     public Font getDefaultFont()
     {
         return DEFAULT_FONT;
+    }
+    
+    /**
+     * Get the effect used to decorate the text. Can be one of {@link AVKey#TEXT_EFFECT_SHADOW} (default), {@link
+     * AVKey#TEXT_EFFECT_OUTLINE} or {@link AVKey#TEXT_EFFECT_NONE}.
+     *
+     * @return the effect used for text rendering.
+     */
+    public String getEffect()
+    {
+        return this.effect;
+    }
+
+    /**
+     * Set the effect used to decorate the text. Can be one of {@link AVKey#TEXT_EFFECT_SHADOW} (default), {@link
+     * AVKey#TEXT_EFFECT_OUTLINE} or {@link AVKey#TEXT_EFFECT_NONE}.
+     *
+     * @param effect the effect to use for text rendering.
+     */
+    public void setEffect(String effect)
+    {
+        if (effect == null)
+        {
+            String msg = Logging.getMessage("nullValue.StringIsNull");
+            Logging.logger().fine(msg);
+            throw new IllegalArgumentException(msg);
+        }
+
+        this.effect = effect;
     }
 
     /**
@@ -255,7 +287,17 @@ public class DeclutteringTextRenderer
                 {
                     background = this.applyOpacity(background, opacity);
                     textRenderer.setColor(background);
-                    textRenderer.draw3D(charSequence, drawPoint.x + xOffset + 1, drawPoint.y + yOffset - 1, 0, 1);
+                    if (this.effect.equals(AVKey.TEXT_EFFECT_SHADOW))
+                    {
+                        textRenderer.draw3D(charSequence, drawPoint.x + xOffset + 1, drawPoint.y + yOffset - 1, 0, 1);
+                    }
+                    else if (this.effect.equals(AVKey.TEXT_EFFECT_OUTLINE))
+                    {
+                        textRenderer.draw3D(charSequence, drawPoint.x + xOffset + 1, drawPoint.y + yOffset - 1, 0, 1);
+                        textRenderer.draw3D(charSequence, drawPoint.x + xOffset + 1, drawPoint.y + yOffset + 1, 0, 1);
+                        textRenderer.draw3D(charSequence, drawPoint.x + xOffset - 1, drawPoint.y + yOffset - 1, 0, 1);
+                        textRenderer.draw3D(charSequence, drawPoint.x + xOffset - 1, drawPoint.y + yOffset + 1, 0, 1);
+                    }
                 }
 
                 textRenderer.setColor(color);

--- a/src/gov/nasa/worldwind/render/DeclutteringTextRenderer.java
+++ b/src/gov/nasa/worldwind/render/DeclutteringTextRenderer.java
@@ -21,8 +21,8 @@ import java.io.IOException;
 import java.util.Iterator;
 
 /**
- * A simplified version of {@link GeographicTextRenderer} that participates in globe text decluttering. See {@link
- * ClutterFilter} for more information on decluttering.
+ * A simplified version of {@link BasicGeographicTextRenderer} that participates in globe text decluttering.
+ * See {@link ClutterFilter} for more information on decluttering.
  *
  * @author tag
  * @version $Id: DeclutteringTextRenderer.java 2392 2014-10-20 20:02:44Z tgaskins $

--- a/src/gov/nasa/worldwind/render/DeclutteringTextRenderer.java
+++ b/src/gov/nasa/worldwind/render/DeclutteringTextRenderer.java
@@ -245,17 +245,21 @@ public class DeclutteringTextRenderer
                 if (color == null)
                     color = DEFAULT_COLOR;
                 color = this.applyOpacity(color, opacity);
+                
+                Offset offset = geographicText.getOffset();
+                float xOffset = offset.getX().floatValue();
+                float yOffset = offset.getY().floatValue();
 
                 Color background = geographicText.getBackgroundColor();
                 if (background != null)
                 {
                     background = this.applyOpacity(background, opacity);
                     textRenderer.setColor(background);
-                    textRenderer.draw3D(charSequence, drawPoint.x + 1, drawPoint.y - 1, 0, 1);
+                    textRenderer.draw3D(charSequence, drawPoint.x + xOffset + 1, drawPoint.y + yOffset - 1, 0, 1);
                 }
 
                 textRenderer.setColor(color);
-                textRenderer.draw3D(charSequence, drawPoint.x, drawPoint.y, 0, 1);
+                textRenderer.draw3D(charSequence, drawPoint.x + xOffset, drawPoint.y + yOffset, 0, 1);
                 textRenderer.flush();
 
                 if (scale != 1d)
@@ -356,8 +360,9 @@ public class DeclutteringTextRenderer
 
             Rectangle2D textBound = textRenderer.getBounds(charSequence);
             double x = screenPoint.x - textBound.getWidth() / 2d;
+            Offset offset = geographicText.getOffset();
             Rectangle2D bounds = new Rectangle2D.Float();
-            bounds.setRect(x, screenPoint.y, textBound.getWidth(), textBound.getHeight());
+            bounds.setRect(x + offset.x, screenPoint.y + offset.y, textBound.getWidth(), textBound.getHeight());
 
             return bounds;
         }

--- a/src/gov/nasa/worldwind/render/GeographicText.java
+++ b/src/gov/nasa/worldwind/render/GeographicText.java
@@ -116,4 +116,21 @@ public interface GeographicText
      * @param d New priority.
      */
     void setPriority(double d);
+    
+    /**
+     * Returns the text offset. The offset determines how to position the text relative to its geographic position.
+     *
+     * @return the text offset.
+     *
+     * @see #setOffset(Offset)
+     */
+    Offset getOffset();
+    
+    /**
+     * Specifies a location relative to the label position at which to align the label. The label text begins at the
+     * point indicated by the offset.
+     *
+     * @param offset Offset that controls where to position the label relative to its geographic location.
+     */
+    void setOffset(Offset offset);
 }

--- a/src/gov/nasa/worldwind/render/GeographicTextRenderer.java
+++ b/src/gov/nasa/worldwind/render/GeographicTextRenderer.java
@@ -678,6 +678,10 @@ public class GeographicTextRenderer
                 if (color == null)
                     color = DEFAULT_COLOR;
                 color = this.applyOpacity(color, opacity);
+                
+                Offset offset = geographicText.getOffset();
+                float xOffset = offset.getX().floatValue();
+                float yOffset = offset.getY().floatValue();
 
                 Color background = geographicText.getBackgroundColor();
                 if (background != null)
@@ -686,19 +690,19 @@ public class GeographicTextRenderer
                     textRenderer.setColor(background);
                     if (this.effect.equals(AVKey.TEXT_EFFECT_SHADOW))
                     {
-                        textRenderer.draw3D(charSequence, drawPoint.x + 1, drawPoint.y - 1, 0, 1);
+                        textRenderer.draw3D(charSequence, drawPoint.x + xOffset + 1, drawPoint.y + yOffset - 1, 0, 1);
                     }
                     else if (this.effect.equals(AVKey.TEXT_EFFECT_OUTLINE))
                     {
-                        textRenderer.draw3D(charSequence, drawPoint.x + 1, drawPoint.y - 1, 0, 1);
-                        textRenderer.draw3D(charSequence, drawPoint.x + 1, drawPoint.y + 1, 0, 1);
-                        textRenderer.draw3D(charSequence, drawPoint.x - 1, drawPoint.y - 1, 0, 1);
-                        textRenderer.draw3D(charSequence, drawPoint.x - 1, drawPoint.y + 1, 0, 1);
+                        textRenderer.draw3D(charSequence, drawPoint.x + xOffset + 1, drawPoint.y + yOffset - 1, 0, 1);
+                        textRenderer.draw3D(charSequence, drawPoint.x + xOffset + 1, drawPoint.y + yOffset + 1, 0, 1);
+                        textRenderer.draw3D(charSequence, drawPoint.x + xOffset - 1, drawPoint.y + yOffset - 1, 0, 1);
+                        textRenderer.draw3D(charSequence, drawPoint.x + xOffset - 1, drawPoint.y + yOffset + 1, 0, 1);
                     }
                 }
 
                 textRenderer.setColor(color);
-                textRenderer.draw3D(charSequence, drawPoint.x, drawPoint.y, 0, 1);
+                textRenderer.draw3D(charSequence, drawPoint.x + xOffset, drawPoint.y + yOffset, 0, 1);
                 textRenderer.flush();
 
                 if (scale != 1d)

--- a/src/gov/nasa/worldwind/render/GeographicTextRenderer.java
+++ b/src/gov/nasa/worldwind/render/GeographicTextRenderer.java
@@ -1,0 +1,15 @@
+/**
+ * Copyright (C) 2014, United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration,
+ * All Rights Reserved.
+ */
+package gov.nasa.worldwind.render;
+
+public interface GeographicTextRenderer
+{
+    String getEffect();
+    
+    void setEffect(String effect);
+    
+    void render(DrawContext dc, Iterable<? extends GeographicText> textIterable);
+}

--- a/src/gov/nasa/worldwind/render/UserFacingText.java
+++ b/src/gov/nasa/worldwind/render/UserFacingText.java
@@ -5,6 +5,7 @@
  */
 package gov.nasa.worldwind.render;
 
+import gov.nasa.worldwind.avlist.AVKey;
 import gov.nasa.worldwind.geom.Position;
 import gov.nasa.worldwind.util.Logging;
 
@@ -23,6 +24,7 @@ public class UserFacingText implements GeographicText
     private Color textBackgroundColor; // Can be null to indicate no background color.
     private boolean isVisible = true;
     double priority;  //used for label culling
+    protected Offset offset = new Offset(0.0, 0.0, AVKey.FRACTION, AVKey.FRACTION);
 
     public UserFacingText(CharSequence text, Position textPosition)
     {
@@ -62,6 +64,16 @@ public class UserFacingText implements GeographicText
     public void setPriority(double priority)
     {
         this.priority = priority;
+    }
+    
+    public Offset getOffset()
+    {
+        return this.offset;
+    }
+    
+    public void setOffset(Offset offset)
+    {
+        this.offset = offset;
     }
 
     public Position getPosition()

--- a/src/gov/nasa/worldwindx/examples/util/OpenStreetMapShapefileLoader.java
+++ b/src/gov/nasa/worldwindx/examples/util/OpenStreetMapShapefileLoader.java
@@ -239,7 +239,7 @@ public class OpenStreetMapShapefileLoader
     protected static class TextAndShapesLayer extends RenderableLayer
     {
         protected ArrayList<GeographicText> labels = new ArrayList<GeographicText>();
-        protected GeographicTextRenderer textRenderer = new GeographicTextRenderer();
+        protected BasicGeographicTextRenderer textRenderer = new BasicGeographicTextRenderer();
 
         public TextAndShapesLayer()
         {


### PR DESCRIPTION
I consolidated the GeographicTextRenderer and DeclutteringTextRenderer classes. The GeographicTextRenderer class was renamed to BasicGeographicTextRenderer so that I could introduce the GeographicTextRenderer interface. The reason for all of this was so that I could use either a normal BasicGeographicTextRenderer or DeclutteringTextRenderer inside the newly added TextLayer class.

I also added a text-offset parameter that is used in both the TextRenderer classes so that we can align the text relative to its geographic position.

The DeclutteringTextRenderer was also modified to include the text-effects found in the BasicGeographicTextRenderer class.