### PR TITLE
fixed LayerList.moveHigher in cases of duplicates

### DIFF
--- a/src/gov/nasa/worldwind/layers/LayerList.java
+++ b/src/gov/nasa/worldwind/layers/LayerList.java
@@ -199,7 +199,7 @@ public class LayerList extends CopyOnWriteArrayList<Layer> implements WWObject
 
     public boolean moveHigher(Layer targetLayer)
     {
-        int index = this.indexOf(targetLayer);
+        int index = this.lastIndexOf(targetLayer);
         if (index < 0)
             return false;
 


### PR DESCRIPTION
If the LayerList contained the same layer more then once, moveHigher did not actually move a visible Layer "higher" (making it visible). Using lastIndexOf, the function should work for all cases as desired.