### PR TITLE
All for property references in XML files

### DIFF
--- a/src/gov/nasa/worldwind/Configuration.java
+++ b/src/gov/nasa/worldwind/Configuration.java
@@ -256,6 +256,11 @@ public class Configuration // Singleton
     public static synchronized String getStringValue(String key)
     {
         Object o = getInstance().properties.getProperty(key);
+		
+		if( o != null && o instanceof String )
+        {
+            o = WWUtil.replacePropertyReferences((String)o);            
+        }
         return o != null ? o.toString() : null;
     }
 

--- a/src/gov/nasa/worldwind/util/WWXML.java
+++ b/src/gov/nasa/worldwind/util/WWXML.java
@@ -816,7 +816,8 @@ public class WWXML
 
         try
         {
-            return xpath.evaluate(path, context);
+            String val = xpath.evaluate(path, context);
+			return WWUtil.replacePropertyReferences(val);
         }
         catch (XPathExpressionException e)
         {


### PR DESCRIPTION
When deploying Worldwind within isolated environments with isloated
WMS servers, there is no way to centralize the definition of the server
name, instead, each of the layer XML files have to be updated.
This change allows any of the WW XML file to contain a property
reference, ${property.name}, and have these properties resolved when the
text is retrieved. Properties can be defined in three different ways;
1)worldwind.xml <Property>, 2) Java system property (-Dproperty.name),
or 3) using the legacy WW properties file.