### PR TITLE
Updated WWXML to support configuration of OutputKeys to format XML

### DIFF
--- a/src/config/worldwind.xml
+++ b/src/config/worldwind.xml
@@ -100,4 +100,12 @@
                    jar:file:milstd2525-symbols.zip!  (local zip archive)  -->
     <Property name="gov.nasa.worldwind.avkey.MilStd2525IconRetrieverPath"
               value="http://worldwind.arc.nasa.gov/milstd2525c/rev1/"/>
+    
+    <!-- WWXML Transformer output features can be specified by listing valid javax.xml.transform.OutputKeys -->
+    <!-- Uncomment the following to have all XML documents created through WWXML pretty printed -->
+    <!--<Property name="gov.nasa.worldwind.util.WWXML.outputkey.1" value="indent,yes"/>
+    <Property name="gov.nasa.worldwind.util.WWXML.outputkey.2" value="{http://xml.apache.org/xslt}indent-amount,4"/>-->
+    
+    <!-- Uncomment the following to allow restorable XML strings to be embedded in other XML documednts -->
+    <!--<Property name="gov.nasa.worldwind.util.RestorableSupport.outputkey.1" value="omit-xml-declaration,yes"/>-->
 </WorldWindConfiguration>

--- a/src/gov/nasa/worldwind/formats/gpx/GpxWriter.java
+++ b/src/gov/nasa/worldwind/formats/gpx/GpxWriter.java
@@ -6,6 +6,7 @@
 package gov.nasa.worldwind.formats.gpx;
 
 import gov.nasa.worldwind.util.Logging;
+import gov.nasa.worldwind.util.WWXML;
 import gov.nasa.worldwind.tracks.Track;
 import gov.nasa.worldwind.tracks.TrackSegment;
 import gov.nasa.worldwind.tracks.TrackPoint;
@@ -153,8 +154,7 @@ public class GpxWriter
 
     private void doFlush() throws javax.xml.transform.TransformerException
     {
-        javax.xml.transform.TransformerFactory factory = javax.xml.transform.TransformerFactory.newInstance();
-        javax.xml.transform.Transformer transformer = factory.newTransformer();
+        javax.xml.transform.Transformer transformer = WWXML.createTransformer();
         javax.xml.transform.Source source = new javax.xml.transform.dom.DOMSource(this.doc);
         transformer.transform(source, this.result);
     }

--- a/src/gov/nasa/worldwind/util/RestorableSupport.java
+++ b/src/gov/nasa/worldwind/util/RestorableSupport.java
@@ -5,6 +5,7 @@
  */
 package gov.nasa.worldwind.util;
 
+import gov.nasa.worldwind.Configuration;
 import gov.nasa.worldwind.avlist.*;
 import gov.nasa.worldwind.geom.*;
 import gov.nasa.worldwind.render.OffsetsList;
@@ -44,7 +45,8 @@ public class RestorableSupport
 {
     protected static final String DEFAULT_DOCUMENT_ELEMENT_TAG_NAME = "restorableState";
     protected static final String DEFAULT_STATE_OBJECT_TAG_NAME = "stateObject";
-
+    private static final String PROP_OUTPUTKEY = RestorableSupport.class.getName() + ".outputkey";
+    
     protected org.w3c.dom.Document doc;
     protected javax.xml.xpath.XPath xpath;
     protected String stateObjectTagName;
@@ -203,14 +205,25 @@ public class RestorableSupport
      */
     public String getStateAsXml()
     {
-        javax.xml.transform.TransformerFactory transformerFactory =
-            javax.xml.transform.TransformerFactory.newInstance();
+        //Check for any restorablestate ouputkeys for the transformer
+        Map<String, String> outputKeys = new HashMap<String,String>();
+        Integer i=1;
+        String outputKey = PROP_OUTPUTKEY + "." + i;
+        String value;
+        while((value = Configuration.getStringValue(outputKey)) != null)
+        {
+            String[] parts = value.split(",");
+            outputKeys.put(parts[0], parts[1]);
+            i++;
+            outputKey = PROP_OUTPUTKEY + "." + i;
+        }       
+        
         try
         {
             // The StringWriter will receive the document xml.
             java.io.StringWriter stringWriter = new java.io.StringWriter();
             // Attempt to write the Document to the StringWriter.
-            javax.xml.transform.Transformer transformer = transformerFactory.newTransformer();
+            javax.xml.transform.Transformer transformer = WWXML.createTransformer(outputKeys);
             transformer.transform(
                 new javax.xml.transform.dom.DOMSource(this.doc),
                 new javax.xml.transform.stream.StreamResult(stringWriter));

--- a/src/gov/nasa/worldwindx/applications/sar/SARAnnotationWriter.java
+++ b/src/gov/nasa/worldwindx/applications/sar/SARAnnotationWriter.java
@@ -6,6 +6,7 @@
 package gov.nasa.worldwindx.applications.sar;
 
 import gov.nasa.worldwind.util.Logging;
+import gov.nasa.worldwind.util.WWXML;
 
 /**
  * @author dcollins
@@ -138,8 +139,7 @@ public class SARAnnotationWriter
 
     private void doFlush() throws javax.xml.transform.TransformerException
     {
-        javax.xml.transform.TransformerFactory factory = javax.xml.transform.TransformerFactory.newInstance();
-        javax.xml.transform.Transformer transformer = factory.newTransformer();
+        javax.xml.transform.Transformer transformer = WWXML.createTransformer();
         javax.xml.transform.Source source = new javax.xml.transform.dom.DOMSource(this.doc);
         transformer.transform(source, this.result);
     }

--- a/src/gov/nasa/worldwindx/examples/kml/ExportKML.java
+++ b/src/gov/nasa/worldwindx/examples/kml/ExportKML.java
@@ -10,6 +10,7 @@ import gov.nasa.worldwind.avlist.AVKey;
 import gov.nasa.worldwind.geom.*;
 import gov.nasa.worldwind.render.*;
 import gov.nasa.worldwind.util.Logging;
+import gov.nasa.worldwind.util.WWXML;
 
 import javax.xml.transform.*;
 import javax.xml.transform.stream.*;
@@ -156,10 +157,11 @@ public class ExportKML
             String xmlString = stringWriter.toString();
 
             // Set up a transformer to pretty-print the XML
-            Transformer transformer = TransformerFactory.newInstance().newTransformer();
-            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-            transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
-
+            Map<String,String> outputKeys = new HashMap<String,String>();
+            outputKeys.put(OutputKeys.INDENT, "yes");
+            outputKeys.put("{http://xml.apache.org/xslt}indent-amount", "4");
+            Transformer transformer = WWXML.createTransformer(outputKeys);
+            
             // Write the pretty-printed document to stdout
             transformer.transform(new StreamSource(new StringReader(xmlString)), new StreamResult(System.out));
         }


### PR DESCRIPTION
Change WWXML to allow for configuring the OutputKeys that control the
output of the XML created from a Transformer. This is primarily to allow
for pretty printing XML docs.
Also updated RestorableSupport to allow configuring the XML produced by
this class independantly from WWXML. This allows for the XML created to
be embedded into other XML documents by disabling the xml-declaration.
Updated other classes that was directly creating Transformers and use
the WWXML.createTransformer() to allow for global configuration of XML
generation.