### PR TITLE
Add null checks to ColladaMeshShape.java

### DIFF
--- a/src/gov/nasa/worldwind/ogc/collada/impl/ColladaMeshShape.java
+++ b/src/gov/nasa/worldwind/ogc/collada/impl/ColladaMeshShape.java
@@ -1192,6 +1192,9 @@ public class ColladaMeshShape extends AbstractGeneralShape
      */
     protected String getTextureSource(ColladaAbstractGeometry geometry)
     {
+        if (this.bindMaterial == null)
+            return null;
+        
         ColladaTechniqueCommon techniqueCommon = this.bindMaterial.getTechniqueCommon();
         if (techniqueCommon == null)
             return null;
@@ -1297,7 +1300,10 @@ public class ColladaMeshShape extends AbstractGeneralShape
      *         available.
      */
     protected ColladaEffect getEffect(ColladaAbstractGeometry geometry)
-    {
+    {   
+        if (this.bindMaterial == null)
+            return null;
+            
         ColladaTechniqueCommon techniqueCommon = this.bindMaterial.getTechniqueCommon();
         if (techniqueCommon == null)
             return null;


### PR DESCRIPTION
getInstanceMaterial() had the check already, but getTextureSource() and getEffect() didn't. After adding it to those two, it's possible to load collada exported from Cinema 4D without textures.