### PR TITLE
BasicDragger: Added null checks DRAG_END case

### DIFF
--- a/src/gov/nasa/worldwind/util/BasicDragger.java
+++ b/src/gov/nasa/worldwind/util/BasicDragger.java
@@ -110,9 +110,12 @@ public class BasicDragger implements SelectListener
 
         if (event.getEventAction().equals(SelectEvent.DRAG_END))
         {
-            this.dragContext.setDragState(AVKey.DRAG_ENDED);
-            this.fireDrag((DragSelectEvent) event);
-            this.dragContext = null;
+            if(this.dragContext != null)
+            {
+                this.dragContext.setDragState(AVKey.DRAG_ENDED);
+                this.fireDrag((DragSelectEvent) event);
+                this.dragContext = null;
+            }
             this.dragging = false;
         }
         else if (event.getEventAction().equals(SelectEvent.DRAG))


### PR DESCRIPTION
I was running into some issues with the dragContext being null when a drag event ended.  It gave a bunch of NPE and made my program unresponsive.  This was my fix for it.  