### PR TITLE
Scalebar vertically centered placement

### DIFF
--- a/src/gov/nasa/worldwind/layers/ScalebarLayer.java
+++ b/src/gov/nasa/worldwind/layers/ScalebarLayer.java
@@ -586,6 +586,11 @@ public class ScalebarLayer extends AbstractLayer
             x = this.locationCenter.x - scaledWidth / 2;
             y = this.locationCenter.y - scaledHeight / 2;
         }
+        else if (this.position.equals(AVKey.NORTH))
+        {
+            x = (viewport.getWidth() - scaledWidth) / 2;
+            y = viewport.getHeight() - scaledHeight - this.borderWidth;
+        }
         else if (this.position.equals(AVKey.NORTHEAST))
         {
             x = viewport.getWidth() - scaledWidth - this.borderWidth;
@@ -594,6 +599,11 @@ public class ScalebarLayer extends AbstractLayer
         else if (this.position.equals(AVKey.SOUTHEAST))
         {
             x = viewport.getWidth() - scaledWidth - this.borderWidth;
+            y = 0d + this.borderWidth;
+        }
+        else if (this.position.equals(AVKey.SOUTH))
+        {
+            x = (viewport.getWidth() - scaledWidth) / 2;
             y = 0d + this.borderWidth;
         }
         else if (this.position.equals(AVKey.NORTHWEST))


### PR DESCRIPTION
Modified the ScalebarLayer so that it can be vertically centered. Thus,
added logic to check if the position is either North or South to
vertically center the scalebar either at the top or bottom of the window
respectively.