### PR TITLE
Restored default Travis CI notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,11 +37,3 @@ deploy:
     skip_cleanup: true
     on:
       tags: true
-
-# Notify the World Wind services mailing list on every build
-notifications:
-  email:
-    recipients:
-      secure: EF6MNNCjtBYNiRxCHOZexEo0IXDmwZduzleIRLrLjo0KG2RT+wzSmPBnhit8PwdkiKZt7B7BAHTKuZXxXE0qK83/aIM5lQNXiNzHwpQ602clJoZGERYD3C/bY++j/rAh7IKcbfBU9JvQBPioz+DbcjBhIeCW1ZoY0yYpM5J2kgJ9J9bAO2Ko1r/W4Do9l3PBZjjenF+OVqwOyHnS2WKuG+roJ6AOIM7mo+VC/SlMCl1z7HV9ksz7fnZfQ/yH3J5xk+oG/kYemyVEEWo1wyutrHqTq1fF+eNjjisfoM546t6sl1lLFWVqlQ25jMhlJZ8q2cKXip0+XACxrrO5h5L3sgP5HKhpgzUxENNXzfd8HTTfDVv6Eoi8vAY2k7UaOxtAwq/IWq8BzwLL/Iq64nr13rQ7qIabEhtfNb/wQo293iN026FriX33dOjDUBG0VuSdC66fUK6Q4h4aNf6yP867TzKXWdp6MLvr1Pz+2SyPUBiNFCx8S34ZbK8uuUXOQWd/5p72+uC+0j0zLmZTXVBq+U1QiTlKzSfh1tTjI4PvAb8MMVY27WS4I7VE4inFCZ6SHk5tlVYwyppF5d8ylQqPi2C8a1bY6+9HC3kU45mmoFC3AydyiAqq5kLUbVWvnRLrYwml1kCLLTIjPG/3DjrjKkEbHJtENY4DY7GW1MSufn4=
-    on_success: always
-    on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 # Directs the Travis CI build service for World Wind Java
 # For more information see https://docs.travis-ci.com/user/customizing-the-build/
 
-# Required to install the jq JSON filter used to parse GitHub API results
-dist: trusty
-sudo: required
-
 # Set up to run the Java build script per the Travis CI documentation
 language: java
 
@@ -20,7 +16,7 @@ before_script:
 
 # Build the project
 script:
-  - ant build -lib .
+  - ant build
 
 # Deploy build artifacts. Travis does not invoke this step for pull request builds
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,17 @@ language: java
 jdk:
   - oraclejdk8
 
+# Install the Ant JUnit package, which is missing from the Travis CI environment. See the Travis documentation: https://docs.travis-ci.com/user/installing-dependencies/#Adding-APT-Packages
+addons:
+  apt:
+    packages:
+      - ant-optional
+
+# Use xvfb to run tests that require a GUI and give it some time to start
 before_script:
-  # Use xvfb to run tests that require a GUI
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
+  - sleep 3
 
 # Build the project
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
 
 # Build the project
 script:
-  - ant build
+  - ant build -lib .
 
 # Deploy build artifacts. Travis does not invoke this step for pull request builds
 deploy:


### PR DESCRIPTION
- Removed the custom notifications block from .travis.yml
- Notifying everyone on every build is now unnecessary, as GitHub protected branches and mandatory pull requests ensure that only successful builds make it into the develop and master branches
- Closes #113