### PR TITLE
Change "World Wind" to "WorldWind"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Directs the Travis CI build service for World Wind Java
+# Directs the Travis CI build service for WorldWind Java
 # For more information see https://docs.travis-ci.com/user/customizing-the-build/
 
 # Set up to run the Java build script per the Travis CI documentation

--- a/Design and Coding Guidelines.html
+++ b/Design and Coding Guidelines.html
@@ -6,7 +6,7 @@
 
 <!-- $Id: Design and Coding Guidelines.html 1171 2013-02-11 21:45:02Z dcollins $ -->
 <body>
-<h1>World Wind Multi-Platform Design and Coding Guidelines</h1>
+<h1>WorldWind Multi-Platform Design and Coding Guidelines</h1>
 
 <h2>General</h2>
 <ul>
@@ -15,9 +15,9 @@
         and all products must run on all those systems.
     </li>
     <li>
-        Read the World Wind API's Overview section for a description of World Wind architecture, design and usage. Read
-        the overview pages of each World Wind package for descriptions of those. These descriptions contain critical
-        information that is not repeated elsewhere. To avoid making mistakes, everyone working on World Wind must read
+        Read the WorldWind API's Overview section for a description of WorldWind architecture, design and usage. Read
+        the overview pages of each WorldWind package for descriptions of those. These descriptions contain critical
+        information that is not repeated elsewhere. To avoid making mistakes, everyone working on WorldWind must read
         them before using or modifying the code.
     </li>
     <li>
@@ -76,11 +76,11 @@
         and when it fails.
     </li>
     <li>
-        World Wind never crashes. Always catch exceptions at least at the highest entry point from the runtime, e.g., UI
+        WorldWind never crashes. Always catch exceptions at least at the highest entry point from the runtime, e.g., UI
         listeners, thread run() methods.
     </li>
     <li>
-        Within a rendering pass World Wind does not touch the disk or the network. Always fork off a thread to do that.
+        Within a rendering pass WorldWind does not touch the disk or the network. Always fork off a thread to do that.
         Use the TaskManager and Retriever systems to start threads during rendering. These are set up to govern thread
         usage to avoid swamping the local machine and the server.
     </li>
@@ -124,7 +124,7 @@
         appropriate exception.
     </li>
     <li>
-        The audience for exceptions is not primarily the user of the client program, but the application or World Wind
+        The audience for exceptions is not primarily the user of the client program, but the application or WorldWind
         developer. Throw exceptions that would let them know immediately that they're using faulty logic or data.
     </li>
 </ul>
@@ -170,8 +170,8 @@
 
 <h2>Offline Mode</h2>
 
-<p>World Wind's use of the network can be disabled by calling {@link gov.nasa.WorldWind.setOfflineMode}. Prior to
-   attempting retrieval of a network resource -- anything addressed by a URL -- World Wind checks the offline-mode
+<p>WorldWind's use of the network can be disabled by calling {@link gov.nasa.WorldWind.setOfflineMode}. Prior to
+   attempting retrieval of a network resource -- anything addressed by a URL -- WorldWind checks the offline-mode
    setting and does not attempt retrieval if the value is true. To honor this contract, all code must check network
    status prior to attempting retrieval of a resource on the network.</p>
 

--- a/GDAL_README.txt
+++ b/GDAL_README.txt
@@ -6,26 +6,26 @@
 
 # $Id: GDAL_README.txt 1171 2013-02-11 21:45:02Z dcollins $
 
-This document provides guidance on deploying applications that use the World Wind GDAL libraries.
+This document provides guidance on deploying applications that use the WorldWind GDAL libraries.
 
 
 Version
 ------------------------------------------------------------
 
-World Wind uses GDAL version 1.7.2, and LizardTech's Decode SDK version 7.0.0.2167.
+WorldWind uses GDAL version 1.7.2, and LizardTech's Decode SDK version 7.0.0.2167.
 
 
 Supported Platforms
 ------------------------------------------------------------
 
-World Wind supports Windows 32/64-bit, Linux 32/64-bit, and Mac OSX. The World Wind SDK therefore contains
+WorldWind supports Windows 32/64-bit, Linux 32/64-bit, and Mac OSX. The WorldWind SDK therefore contains
 GDAL, PROJ4, and MRSiD binaries for the following platforms:
  - MacOSX universal
  - Windows 32-bit and Windows 64-bit
  - Linux 32-bit and Linux 64-bit
 
 
-World Wind GDAL Libraries
+WorldWind GDAL Libraries
 ------------------------------------------------------------
 
 To simplify deployment, our GDAL+PRO4+MRSID bundles are compiled as a single dynamic library which has all dependent
@@ -36,7 +36,7 @@ GDAL and PROJ4 libraries require data tables located in the lib-external/gdal/da
 tables in the "data" sub-folder.
 
 WWJ attempts to locate GDAL bundles during the startup. By default WWJ will first look for GDAL native binaries in the
-current path, then in to the lib-external/gdal/ folder. If no GDAL bundle was found World Wind attempts to locate the
+current path, then in to the lib-external/gdal/ folder. If no GDAL bundle was found WorldWind attempts to locate the
 GDAL bundle in the sub-folders. Therefore we recommend one of two options:
 1) Place the GDAL libraries in the folder "lib-external/gdal".
 2) Place the GDAL libraries in the application's root folder.
@@ -45,5 +45,5 @@ GDAL bundle in the sub-folders. Therefore we recommend one of two options:
 Deploying with Java Web Start
 ------------------------------------------------------------
 
-Instructions for using the World Wind GDAL libraries with a Java Web Start application are available at
+Instructions for using the WorldWind GDAL libraries with a Java Web Start application are available at
 https://goworldwind.org/getting-started/

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 <img src="https://worldwind.arc.nasa.gov/css/images/nasa-logo.svg" height="100"/>
 
-# World Wind Java
+# WorldWind Java
 
 [![Build Status](https://travis-ci.org/NASAWorldWind/WorldWindJava.svg?branch=develop)](https://travis-ci.org/NASAWorldWind/WorldWindJava)
 
 3D virtual globe API for desktop Java, developed by NASA. Provides a geographic context with high-resolution terrain, for visualizing geographic or geo-located information in 3D and 2D. Developers can customize the globe's terrain and imagery. Provides a collection of shapes for displaying and interacting with geographic data and representing a range of geometric objects.
 
 - [worldwind.arc.nasa.gov](https://worldwind.arc.nasa.gov) has setup instructions, developers guides, API documentation and more
-- [World Wind Forum](https://forum.worldwindcentral.com) provides help from the World Wind community
-- [IntelliJ IDEA](https://www.jetbrains.com/idea) is used by the NASA World Wind development team
+- [WorldWind Forum](https://forum.worldwindcentral.com) provides help from the WorldWind community
+- [IntelliJ IDEA](https://www.jetbrains.com/idea) is used by the NASA WorldWind development team
 
 ## Releases and Roadmap
 
-Official World Wind Java releases have the latest stable features, enhancements and bug fixes ready for production use.
+Official WorldWind Java releases have the latest stable features, enhancements and bug fixes ready for production use.
 
 - [GitHub Releases](https://github.com/NASAWorldWind/WorldWindJava/releases/) documents official releases
 - [GitHub Milestones](https://github.com/NASAWorldWind/WorldWindJava/milestones) documents upcoming releases and the development roadmap
@@ -22,7 +22,7 @@ Official World Wind Java releases have the latest stable features, enhancements 
    
 ###### From a Web Browser
    
-- [World Wind Demo App](https://worldwind.arc.nasa.gov/java/latest/webstart/ApplicationTemplate.jnlp) shows World Wind's basic capabilities
+- [WorldWind Demo App](https://worldwind.arc.nasa.gov/java/latest/webstart/ApplicationTemplate.jnlp) shows WorldWind's basic capabilities
 - [Java Demos](https://goworldwind.org/demos) has a complete list of example apps
    
 ###### From a Windows Development Environment
@@ -30,7 +30,7 @@ Official World Wind Java releases have the latest stable features, enhancements 
 - Download and extract the [Latest Release](https://github.com/NASAWorldWind/WorldWindJava/releases/latest)
 - Open the Command Prompt
 ```bash
-cd [World Wind release]
+cd [WorldWind release]
 run-demo.bat
 ```
 
@@ -39,13 +39,13 @@ run-demo.bat
 - Download and extract the [Latest Release](https://github.com/NASAWorldWind/WorldWindJava/releases/latest)
 - Open the Terminal app
 ```bash
-cd [World Wind release]
+cd [WorldWind release]
 sh run-demo.bash
 ```
 
 ###### Troubleshooting
    
-World Wind requires a modern graphics card with a current driver. Most display problems are caused by out-of-date 
+WorldWind requires a modern graphics card with a current driver. Most display problems are caused by out-of-date 
 graphics drivers. On Windows, visit your graphics card manufacturer's web site for the latest driver: NVIDIA, ATI or 
 Intel. The drivers are typically under a link named Downloads or Support. If you're using a laptop, the latest drivers 
 are found at the laptop manufacturer's web site.
@@ -53,7 +53,7 @@ are found at the laptop manufacturer's web site.
 ## JOGL Native Binaries
 
 JOGL performs runtime extraction of native binaries. Some deployment situations may not allow this because it extracts 
-the binaries to the application user’s temp directory. Runtime extraction can be avoided by by modifying World Wind 
+the binaries to the application user’s temp directory. Runtime extraction can be avoided by by modifying WorldWind 
 Java's JOGL distribution to load native binaries directly from the library path instead of dynamically using the native 
 binary JAR files as follows:
                                                                                                      
@@ -69,7 +69,7 @@ binary JAR files as follows:
 
 ## License
 
-    NASA WORLD WIND
+    NASA WorldWind
 
     Copyright (C) 2001 United States Government
     as represented by the Administrator of the
@@ -90,7 +90,7 @@ binary JAR files as follows:
 
     Government Agency: National Aeronautics and Space Administration (NASA)
     Government Agency Original Software Designation: ARC-15166-1
-    Government Agency Original Software Title: NASA World Wind
+    Government Agency Original Software Title: NASA WorldWind
     User Registration Requested. Please send email with your contact information to Patrick.Hogan@nasa.gov
     Government Agency Point of Contact for Original Software: Patrick.Hogan@nasa.gov
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ binary JAR files as follows:
 
 ## License
 
-    NASA WorldWind
+    NASA WORLDWIND
 
     Copyright (C) 2001 United States Government
     as represented by the Administrator of the

--- a/README_DEVELOPER.txt
+++ b/README_DEVELOPER.txt
@@ -6,23 +6,23 @@
 
 # $Id: README_DEVELOPER.txt 1934 2014-04-15 19:24:07Z dcollins $
 
-This document provides notes and instructions for World Wind Java development team members in one place.
+This document provides notes and instructions for WorldWind Java development team members in one place.
 
 
 JOGL Library Overview
 ------------------------------------------------------------
 
-The JOGL library provides World Wind Java with (1) a Java binding to the OpenGL API, and (2) OpenGL contexts compatible
+The JOGL library provides WorldWind Java with (1) a Java binding to the OpenGL API, and (2) OpenGL contexts compatible
 with Java's AWT and Swing windowing toolkits:
 http://jogamp.org/jogl/www/
 
-World Wind Java uses JOGL v2.1.5, released on 11 March 2014 and downloaded from:
+WorldWind Java uses JOGL v2.1.5, released on 11 March 2014 and downloaded from:
 http://jogamp.org/deployment/v2.1.5/archive/jogamp-all-platforms.7z
 
-The JOGL library compiled JAR files and README files are checked into the World Wind Java source, distributed with all
-World Wind Java builds and included in the World Wind Java Web Start deployment. This is necessary in order ensure
-correct operation of World Wind Java, as changes in JOGL are occasionally unstable or incompatible with previous
-versions. Additionally, World Wind Java's copy of the JOGL JAR files are modified to enable Web Start deployment outside
+The JOGL library compiled JAR files and README files are checked into the WorldWind Java source, distributed with all
+WorldWind Java builds and included in the WorldWind Java Web Start deployment. This is necessary in order ensure
+correct operation of WorldWind Java, as changes in JOGL are occasionally unstable or incompatible with previous
+versions. Additionally, WorldWind Java's copy of the JOGL JAR files are modified to enable Web Start deployment outside
 of the jogamp.org domain.
 
 
@@ -33,7 +33,7 @@ Updating the JOGL Library
 packages are organized by version at the following URL:
 http://jogamp.org/deployment/
 
-2) Extract the archive, then copy the following 15 files to the World Wind Java project root:
+2) Extract the archive, then copy the following 15 files to the WorldWind Java project root:
 gluegen-rt-natives-linux-amd64.jar
 gluegen-rt-natives-linux-i586.jar
 gluegen-rt-natives-macosx-universal.jar
@@ -51,7 +51,7 @@ jogl.LICENSE.txt
 jogl.README.txt
 
 3) Remove the Codebase manifest attribute from all JOGL JAR files. This step enables the JOGL JAR files to be
-deployed via the World Wind Java Web Start site:
+deployed via the WorldWind Java Web Start site:
 - Run the ANT task jogl.jarfiles.unpack. This task extracts the contents of all 12 GlueGen and JOGL JAR files into
 individual folders under jogl-jarfiles.
 - For each JAR file folder under jogl-jarfiles open the file META-INF/MANIFEST.MF, delete the line

--- a/VPF_README.txt
+++ b/VPF_README.txt
@@ -12,7 +12,7 @@ to build it.
 
 1) PURPOSE OF VPF-SYMBOLS.JAR
 
-The JAR file vpf-symbols.jar found in the World Wind Java SDK contains style definitions and PNG icons for Vector
+The JAR file vpf-symbols.jar found in the WorldWind Java SDK contains style definitions and PNG icons for Vector
 Product Format (VPF) shapes. vpf-symbols.jar is 1.8 MB in size, and is therefore distributed separately to avoid
 increasing the size of worldwind.jar for the sake of supporting VPF, an uncommonly used feature.
 
@@ -25,17 +25,17 @@ GeoSym: http://www.gwg.nga.mil/pfg_documents.php
 2) USING VPF-SYMBOLS.JAR
 
 The JAR file vpf-symbols.jar must be distributed and included in the runtime class-path by applications using the World
-Wind class gov.nasa.worldwind.formats.vpf.VPFLayer. When added to an application's class-path, World Wind VPF shapes
+Wind class gov.nasa.worldwind.formats.vpf.VPFLayer. When added to an application's class-path, WorldWind VPF shapes
 automatically find and locate style and icon resources contained within this JAR file.
 
-If vpf-symbols.jar is not in the Java class-path, VPFLayer outputs the following message in the World Wind log:
+If vpf-symbols.jar is not in the Java class-path, VPFLayer outputs the following message in the WorldWind log:
 "WARNING: GeoSym style support is disabled". In this case, VPF shapes are displayed as gray outlines, and icons are
 displayed as a gray question mark.
 
 
 3) BUILDING VPF-SYMBOLS.JAR
 
-To build or reconstruct the VPF symbols JAR file for the World Wind Java SDK, follow these six steps:
+To build or reconstruct the VPF symbols JAR file for the WorldWind Java SDK, follow these six steps:
 
 - Download and extract the GeoSym Second Edition package.
 Download the GeoSym archive from the National Geospatial-Intelligence Agency (NGA) at the following page, then extract
@@ -60,7 +60,7 @@ on ImageIO.
 - Copy all GeoSym style tables.
 Copy all files under the directory GeoSymEd2Final/SYMASGN/ASCII to the directory geosym/symasgn/ascii.
 
-- Convert GeoSym line and area styles to World Wind shape attributes.
+- Convert GeoSym line and area styles to WorldWind shape attributes.
 Run the Java application gov.nasa.worldwind.formats.vpf.GeoSymAttributeConverter from the shell, passing the full path
 to GeoSymEd2Final/GRAPHICS/TEXT as the application's only parameter. Copy the output PNG files under
 gsac-out/geosym/graphics/bin to the following directory created earlier: geosym/graphics/bin. Copy the output CSV files 

--- a/build.macros.xml
+++ b/build.macros.xml
@@ -13,7 +13,7 @@
          on the current machine, resulting in unpredictable class versions.
 
          The javac compiler argument '-Xlint:unchecked' is specified in order to give more detail for unchecked
-         conversion warnings. This argument is specified in the World Wind Java IntelliJ IDEA project. Its use here
+         conversion warnings. This argument is specified in the WorldWind Java IntelliJ IDEA project. Its use here
          keeps ANT compiled classes in sync with the IntelliJ IDEA compiled classes. -->
 
     <macrodef name="compileJava">
@@ -42,15 +42,15 @@
 
     <!-- Macros for bundling library JAR files.
 
-         The World Wind core JAR file includes all class files, property files, configuration files, and image files
+         The WorldWind core JAR file includes all class files, property files, configuration files, and image files
          under the package gov.nasa.worldwind, all class files under the package com.zebraimaging, and optionally all
          class files under the package org.codehaus.jackson (depending on the worldwind.exclude.jackson property).
          The zebraimaging package includes an alternative input handler for the Zebra Imaging display controller. The
          jackson package includes the Jackson JSON parsing library which is used by gov.nasa.worldwind.formats.geojson.
          Requires jogl-all.jar, gluegen-rt.jar, gdal.jar on the class path.
 
-         The World Wind extensions JAR file includes all class files, configuration files, image files, and data
-         resource files under the package gov.nasa.worldwindx. Requires the World Wind core JAR file on the class path.
+         The WorldWind extensions JAR file includes all class files, configuration files, image files, and data
+         resource files under the package gov.nasa.worldwindx. Requires the WorldWind core JAR file on the class path.
 
          All JAR files have the Permissions attribute set to "all-permissions". This attribute is ignored for locally
          launched applications, but is required for signed Web Start Applications. This property must match the setting

--- a/build.properties
+++ b/build.properties
@@ -5,10 +5,10 @@
 #
 
 #***********************************************************************************************
-# Properties for the World Wind Java ANT build
+# Properties for the WorldWind Java ANT build
 #***********************************************************************************************
 
-# World Wind library and test build properties
+# WorldWind library and test build properties
 worldwind.src.dir=${basedir}/src
 worldwind.test.dir=${basedir}/test
 worldwind.build.dir=${basedir}/build

--- a/build.xml
+++ b/build.xml
@@ -7,8 +7,8 @@
 
 <project name="worldwind" default="build" basedir=".">
     <description>
-        Build script for World Wind Java. Assembles and tests the World Wind source code, creates World Wind API
-        documentation, and bundles World Wind library JAR files.
+        Build script for WorldWind Java. Assembles and tests the WorldWind source code, creates WorldWind API
+        documentation, and bundles WorldWind library JAR files.
     </description>
 
     <!-- Import the ANT build properties and project ANT macros. -->
@@ -87,7 +87,7 @@
         <javadoc destdir="${worldwind.doc.dir}/javadoc"
                  overview="${worldwind.src.dir}/overview.html"
                  encoding="UTF-8"
-                 windowtitle="NASA World Wind" doctitle="NASA World Wind" header="NASA World Wind"
+                 windowtitle="NASA WorldWind" doctitle="NASA WorldWind" header="NASA WorldWind"
                  splitindex="true" protected="true" nodeprecated="true" version="false" author="false" use="true"
                  maxmemory="1024m">
             <packageset dir="${worldwind.src.dir}" defaultexcludes="yes">
@@ -134,7 +134,7 @@
 
     <target name="bundleWebStartLibraries">
         <mkdir dir="${webstart.unsigned.dir}"/>
-        <!-- World Wind library JAR files. -->
+        <!-- WorldWind library JAR files. -->
         <copy file="${worldwind.jar.dir}/release/worldwind.jar" tofile="${webstart.unsigned.dir}/worldwind.jar"/>
         <copy file="${worldwind.jar.dir}/release/worldwindx.jar" tofile="${webstart.unsigned.dir}/worldwindx.jar"/>
         <!-- JOGL and GlueGen library JAR files. -->
@@ -428,7 +428,7 @@
 
     <!-- Helper tasks for bundling and unbundling the JOGL and GLueGen JAR files. Each Jar file is extracted to a folder
          matching the filename without its suffix. These targets are used to modify JOGL and GlueGen Jar file manifests
-         in order to deploy these files from the World Wind Java Web Start site. -->
+         in order to deploy these files from the WorldWind Java Web Start site. -->
 
     <target name="help.unpackJogl">
         <property name="jogl.jarfiles.dir" location="jogl-jarfiles"/>
@@ -528,7 +528,7 @@
     </target>
 
     <!-- Helper tasks for compiling and linking the WebView native library for the current platform. Output libraries
-         are placed in the World Wind project root folder and overwrite any existing files of the same name.
+         are placed in the WorldWind project root folder and overwrite any existing files of the same name.
 
          On Mac OS X this compiles the Objective-C sources under the folder 'lib-external/webview/macosx' into
          'libwebview.jnilib', and requires that the XCode and Java development toolkits for Mac are installed.

--- a/lib-external/webview/macosx/JNIUtil.m
+++ b/lib-external/webview/macosx/JNIUtil.m
@@ -882,7 +882,7 @@ void InitLoggerJNI(JNIEnv *env)
         return;
 
     // Initialize the logging class and methodID pointers. We do this here rather than after obtaining an environment in
-    // the *ObtainEnv functions because the World Wind Java classes cannot be found from the AppKit thread. By finding
+    // the *ObtainEnv functions because the WorldWind Java classes cannot be found from the AppKit thread. By finding
     // them here and retaining a reference to them, we make them accessible by calls to *ObtainEnv from the AppKit
     // thread. Note that this stores the class and method references in static variables, and therefore assumes that
     // there is one class definition for gov.nasa.worldwind.util.Logging in the JNI environment.

--- a/lib-external/webview/macosx/WebResourceResolver.m
+++ b/lib-external/webview/macosx/WebResourceResolver.m
@@ -55,7 +55,7 @@ static jmethodID WebResourceResolver_resolve = NULL;
     if (WebResourceResolver_class == NULL)
     {
         // Initialize the WebResourceResolver class and methodID pointers when the first WebResourceResolver is created.
-        // We do this here rather than after obtaining an environment in resolve because the World Wind Java classes
+        // We do this here rather than after obtaining an environment in resolve because the WorldWind Java classes
         // cannot be found from the AppKit thread. By finding them here and retaining a reference to them, we make them
         // accessible by calls to resolve from the AppKit thread. Note that this stores the class and method references
         // in static variables, and therefore assumes that there is one class definition for

--- a/lib-external/webview/windows/README.txt
+++ b/lib-external/webview/windows/README.txt
@@ -17,7 +17,7 @@ Building the library
 --------------------
 
 The library is built using Microsoft NMake. The build process can be launched from ant using the ant task
-native.webview.libraries, defined in the World Wind build.xml file.
+native.webview.libraries, defined in the WorldWind build.xml file.
 
 To build using ant:
 

--- a/src/com/zebraimaging/ZebraInputHandler.java
+++ b/src/com/zebraimaging/ZebraInputHandler.java
@@ -12,7 +12,7 @@ import java.util.List;
 /**
  * An alternative input handler used to synchronize input with the Zebra Imaging display controller. Applications are
  * not expected to create instances of this class directly or call its methods. To use it, specify it as the
- * gov.nasa.worldwind.avkey.InputHandlerClassName in the World Wind configuration file.
+ * gov.nasa.worldwind.avkey.InputHandlerClassName in the WorldWind configuration file.
  */
 public class ZebraInputHandler extends AWTInputHandler
 {

--- a/src/config/DataFileStore.xml
+++ b/src/config/DataFileStore.xml
@@ -6,13 +6,13 @@
   -->
 
 <!--
-  ~ World Wind data-file store configuration
+  ~ WorldWind data-file store configuration
   ~
   ~ $Id: DataFileStore.xml 1171 2013-02-11 21:45:02Z dcollins $
   -->
 <dataFileStore>
     <readLocations>
-        <!-- The read locations are searched, in the given order, when World Wind needs a data or image file. -->
+        <!-- The read locations are searched, in the given order, when WorldWind needs a data or image file. -->
         <!-- The write location selected from the writeLocations list is searched before these locations. -->
         <location property="gov.nasa.worldwind.platform.alluser.store" wwDir="WorldWindData"/>
         <location property="gov.nasa.worldwind.platform.user.store"    wwDir="WorldWindData"/>

--- a/src/config/worldwind.layers.xml
+++ b/src/config/worldwind.layers.xml
@@ -6,7 +6,7 @@
   -->
 
 <!--$Id: worldwind.layers.xml 2256 2014-08-22 17:46:18Z tgaskins $-->
-<!--This document specifies the initial layers to load in World Wind-->
+<!--This document specifies the initial layers to load in WorldWind-->
 <!--This list can be overridden by specifying an alternate list in worldwind.xml, or by specifying an-->
 <!--alternate configuration document-->
 <!--See the javadoc for the Configuration class for details-->

--- a/src/config/worldwind.xml
+++ b/src/config/worldwind.xml
@@ -6,7 +6,7 @@
   -->
 
 <!--$Id: worldwind.xml 2348 2014-09-25 23:35:46Z dcollins $-->
-<!--Default World Wind configuration values-->
+<!--Default WorldWind configuration values-->
 <!--Any of these can be overridden by specifying an application configuration document-->
 <!--An alternate document to this one can also be specified-->
 <!--See the javadoc for the Configuration class for details-->
@@ -65,7 +65,7 @@
     <Property name="gov.nasa.worldwind.avkey.DataFileStoreConfigurationFileName" value="config/DataFileStore.xml"/>
     <Property name="gov.nasa.worldwind.avkey.WorldMapImagePath" value="images/earth-map-512x256.dds"/>
     <Property name="gov.nasa.worldwind.StarsLayer.StarsFileName" value="config/Hipparcos_Stars_Mag6x5044.dat"/>
-    <!--The following are tuning parameters for various World Wind internals-->
+    <!--The following are tuning parameters for various WorldWind internals-->
     <Property name="gov.nasa.worldwind.avkey.RetrievalPoolSize" value="4"/>
     <Property name="gov.nasa.worldwind.avkey.RetrievalQueueSize" value="200"/>
     <Property name="gov.nasa.worldwind.avkey.RetrievalStaleRequestLimit" value="9000"/>

--- a/src/gov/nasa/worldwind/Configuration.java
+++ b/src/gov/nasa/worldwind/Configuration.java
@@ -18,7 +18,7 @@ import java.util.*;
 import java.util.logging.Level;
 
 /**
- * This class manages the initial World Wind configuration. It reads World Wind configuration files and registers their
+ * This class manages the initial WorldWind configuration. It reads WorldWind configuration files and registers their
  * contents. Configurations files contain the names of classes to create at run-time, the initial model definition,
  * including the globe, elevation model and layers, and various control quantities such as cache sizes and data
  * retrieval timeouts.
@@ -28,21 +28,21 @@ import java.util.logging.Level;
  * <p/>
  * When the Configuration class is first instantiated it reads the XML document <code>config/worldwind.xml</code> and
  * registers all the information there. The information can subsequently be retrieved via the class' various
- * <code>getValue</code> methods. Many World Wind start-up objects query this information to determine the classes to
- * create. For example, the first World Wind object created by an application is typically a {@link
- * gov.nasa.worldwind.awt.WorldWindowGLCanvas}. During construction that class causes World Wind's internal classes to
+ * <code>getValue</code> methods. Many WorldWind start-up objects query this information to determine the classes to
+ * create. For example, the first WorldWind object created by an application is typically a {@link
+ * gov.nasa.worldwind.awt.WorldWindowGLCanvas}. During construction that class causes WorldWind's internal classes to
  * be constructed, using the names of those classes drawn from the Configuration singleton, this class.
  * <p/>
- * The default World Wind configuration document is <code>config/worldwind.xml</code>. This can be changed by setting
+ * The default WorldWind configuration document is <code>config/worldwind.xml</code>. This can be changed by setting
  * the Java property <code>gov.nasa.worldwind.config.file</code> to a different file name or a valid URL prior to
- * creating any World Wind object or invoking any static methods of World Wind classes, including the Configuration
+ * creating any WorldWind object or invoking any static methods of WorldWind classes, including the Configuration
  * class. When an application specifies a different configuration location it typically does so in its main method prior
- * to using World Wind. If a file is specified its location must be on the classpath. (The contents of application and
- * World Wind jar files are typically on the classpath, in which case the configuration file may be in the jar file.)
+ * to using WorldWind. If a file is specified its location must be on the classpath. (The contents of application and
+ * WorldWind jar files are typically on the classpath, in which case the configuration file may be in the jar file.)
  * <p/>
  * Additionally, an application may set another Java property, <code>gov.nasa.worldwind.app.config.document</code>, to a
  * file name or URL whose contents contain configuration values to override those of the primary configuration document.
- * World Wind overrides only those values in this application document, it leaves all others to the value specified in
+ * WorldWind overrides only those values in this application document, it leaves all others to the value specified in
  * the primary document. Applications usually specify an override document in order to specify the initial layers in the
  * model.
  * <p/>
@@ -54,7 +54,7 @@ import java.util.logging.Level;
  * <em>Note:</em> Prior to September of 2009, configuration properties were read from the file
  * <code>config/worldwind.properties</code>. An alternate file could be specified via the
  * <code>gov.nasa.worldwind.config.file</code> Java property. These mechanisms remain available but are deprecated.
- * World Wind no longer contains a <code>worldwind.properties</code> file. If <code>worldwind.properties</code> or its
+ * WorldWind no longer contains a <code>worldwind.properties</code> file. If <code>worldwind.properties</code> or its
  * replacement as specified through the Java property exists at run-time and can be found via the classpath,
  * configuration values specified by that mechanism are given precedence over values specified by the new mechanism.
  *
@@ -644,7 +644,7 @@ public class Configuration // Singleton
     }
 
     /**
-     * Returns the highest OpenGL profile available on the current graphics device that is compatible with World Wind.
+     * Returns the highest OpenGL profile available on the current graphics device that is compatible with WorldWind.
      * The returned profile favors hardware acceleration over software acceleration. With JOGL version 2.0, this returns
      * the highest available profile from the following list:
      * <p/>
@@ -659,7 +659,7 @@ public class Configuration // Singleton
     }
 
     /**
-     * Returns a {@link javax.media.opengl.GLCapabilities} identifying graphics features required by World Wind. The
+     * Returns a {@link javax.media.opengl.GLCapabilities} identifying graphics features required by WorldWind. The
      * capabilities instance returned requests the maximum OpenGL profile supporting GL fixed function operations, a
      * frame buffer with 8 bits each of red, green, blue and alpha, a 24-bit depth buffer, double buffering, and if the
      * Java property "gov.nasa.worldwind.stereo.mode" is set to "device", device supported stereo.

--- a/src/gov/nasa/worldwind/StereoOptionSceneController.java
+++ b/src/gov/nasa/worldwind/StereoOptionSceneController.java
@@ -35,7 +35,7 @@ import javax.media.opengl.*;
 public class StereoOptionSceneController extends BasicSceneController implements StereoSceneController
 {
     /**
-     * The default focus angle. May be specified in the World Wind configuration file as the
+     * The default focus angle. May be specified in the WorldWind configuration file as the
      * <code>gov.nasa.worldwind.StereoFocusAngle</code> property. The default if not specified in the configuration is
      * 1.6 degrees.
      */

--- a/src/gov/nasa/worldwind/Version.java
+++ b/src/gov/nasa/worldwind/Version.java
@@ -16,7 +16,7 @@ public class Version
     private static final String MINOR_VALUE = "1";
     private static final String DOT_VALUE = "0";
     private static final String versionNumber = "v" + MAJOR_VALUE + "." + MINOR_VALUE + "." + DOT_VALUE;
-    private static final String versionName = "NASA World Wind Java";
+    private static final String versionName = "NASA WorldWind Java";
 
     public static String getVersion()
     {

--- a/src/gov/nasa/worldwind/View.java
+++ b/src/gov/nasa/worldwind/View.java
@@ -262,7 +262,7 @@ public interface View extends WWObject, Restorable
      * reflects the values of this view, as do any computed values of the view, such as the modelview matrix, projection
      * matrix and viewing frustum.
      *
-     * @param dc the current World Wind DrawContext on which <code>View</code> will apply its state.
+     * @param dc the current WorldWind DrawContext on which <code>View</code> will apply its state.
      *
      * @throws IllegalArgumentException If <code>dc</code> is null, or if the <code>Globe</code> or <code>GL</code>
      *                                  instances in <code>dc</code> are null.
@@ -303,7 +303,7 @@ public interface View extends WWObject, Restorable
      * popReferenceCenter} after rendering is complete. Note that calls to {@link #getModelviewMatrix} will not return
      * reference-center model-view matrix, but the original matrix.
      *
-     * @param dc              the current World Wind drawing context on which new model-view state will be applied.
+     * @param dc              the current WorldWind drawing context on which new model-view state will be applied.
      * @param referenceCenter the location to become the new world origin.
      *
      * @return a new model-view matrix with origin is at <code>referenceCenter</code>, or null if this method failed.
@@ -316,7 +316,7 @@ public interface View extends WWObject, Restorable
     /**
      * Removes the model-view matrix on top of the matrix stack, and restores the original matrix.
      *
-     * @param dc the current World Wind drawing context on which the original matrix will be restored.
+     * @param dc the current WorldWind drawing context on which the original matrix will be restored.
      *
      * @throws IllegalArgumentException if <code>dc</code> is null, or if the <code>Globe</code> or <code>GL</code>
      *                                  instances in <code>dc</code> are null.

--- a/src/gov/nasa/worldwind/WWObject.java
+++ b/src/gov/nasa/worldwind/WWObject.java
@@ -10,7 +10,7 @@ import gov.nasa.worldwind.avlist.AVList;
 import gov.nasa.worldwind.event.MessageListener;
 
 /**
- * An interface provided by the major World Wind components to provide attribute-value list management and
+ * An interface provided by the major WorldWind components to provide attribute-value list management and
  * property change management. Classifies implementers as property-change listeners, allowing them to receive
  * property-change events.
  *

--- a/src/gov/nasa/worldwind/WorldWind.java
+++ b/src/gov/nasa/worldwind/WorldWind.java
@@ -94,16 +94,16 @@ public final class WorldWind
     }
 
     /**
-     * Reinitialize World Wind to its initial ready state. Shut down and restart all World Wind services and clear all
-     * World Wind memory caches. Cache memory will be released at the next JVM garbage collection.
+     * Reinitialize WorldWind to its initial ready state. Shut down and restart all WorldWind services and clear all
+     * WorldWind memory caches. Cache memory will be released at the next JVM garbage collection.
      * <p/>
-     * Call this method to reduce World Wind's current resource usage to its initial, empty state.
+     * Call this method to reduce WorldWind's current resource usage to its initial, empty state.
      * <p/>
      * The state of any open {@link WorldWindow} objects is indeterminate subsequent to invocation of this method. The
      * core WorldWindow objects attempt to shut themselves down cleanly during the call, but their resulting window
      * state is undefined.
      * <p/>
-     * World Wind can continue to be used after calling this method.
+     * WorldWind can continue to be used after calling this method.
      */
     public static synchronized void shutDown()
     {
@@ -169,9 +169,9 @@ public final class WorldWind
     }
 
     /**
-     * Indicates whether World Wind will attempt to connect to the network to retrieve data or for other reasons.
+     * Indicates whether WorldWind will attempt to connect to the network to retrieve data or for other reasons.
      *
-     * @return <code>true</code> if World Wind is in off-line mode, <code>false</code> if not.
+     * @return <code>true</code> if WorldWind is in off-line mode, <code>false</code> if not.
      *
      * @see NetworkStatus
      */
@@ -181,10 +181,10 @@ public final class WorldWind
     }
 
     /**
-     * Indicate whether World Wind should attempt to connect to the network to retrieve data or for other reasons. The
+     * Indicate whether WorldWind should attempt to connect to the network to retrieve data or for other reasons. The
      * default value for this attribute is <code>false</code>, indicating that the network should be used.
      *
-     * @param offlineMode <code>true</code> if World Wind should use the network, <code>false</code> otherwise
+     * @param offlineMode <code>true</code> if WorldWind should use the network, <code>false</code> otherwise
      *
      * @see NetworkStatus
      */

--- a/src/gov/nasa/worldwind/WorldWindow.java
+++ b/src/gov/nasa/worldwind/WorldWindow.java
@@ -17,7 +17,7 @@ import javax.media.opengl.GLContext;
 import java.util.*;
 
 /**
- * The top-level interface common to all toolkit-specific World Wind windows.
+ * The top-level interface common to all toolkit-specific WorldWind windows.
  *
  * @author Tom Gaskins
  * @version $Id: WorldWindow.java 2047 2014-06-06 22:48:33Z tgaskins $
@@ -94,43 +94,43 @@ public interface WorldWindow extends AVList
     /**
      * Sets the input handler to use for this instance.
      *
-     * @param inputHandler The input handler to use for this world window. May by <code>null</code> if <code>null</code>
-     *                     is specified, the current input handler, if any, is disassociated with the world window.
+     * @param inputHandler The input handler to use for this WorldWindow. May by <code>null</code> if <code>null</code>
+     *                     is specified, the current input handler, if any, is disassociated with the WorldWindow.
      */
     void setInputHandler(InputHandler inputHandler);
 
     /**
-     * Adds a rendering listener to this world window. Rendering listeners are called at key point during World Wind
+     * Adds a rendering listener to this WorldWindow. Rendering listeners are called at key point during WorldWind
      * drawing and provide applications the ability to participate or monitor rendering.
      *
-     * @param listener The rendering listener to add to those notified of rendering events by this world window.
+     * @param listener The rendering listener to add to those notified of rendering events by this WorldWindow.
      */
     void addRenderingListener(RenderingListener listener);
 
     /**
-     * Removes a specified rendering listener associated with this world window.
+     * Removes a specified rendering listener associated with this WorldWindow.
      *
      * @param listener The rendering listener to remove.
      */
     void removeRenderingListener(RenderingListener listener);
 
     /**
-     * Adds a select listener to this world window. Select listeners are called when a selection is made by the user in
-     * the world window. A selection is any operation that identifies a visible item.
+     * Adds a select listener to this WorldWindow. Select listeners are called when a selection is made by the user in
+     * the WorldWindow. A selection is any operation that identifies a visible item.
      *
      * @param listener The select listener to add.
      */
     void addSelectListener(SelectListener listener);
 
     /**
-     * Removes the specified select listener associated with this world window.
+     * Removes the specified select listener associated with this WorldWindow.
      *
      * @param listener The select listener to remove.
      */
     void removeSelectListener(SelectListener listener);
 
     /**
-     * Adds a position listener to this world window. Position listeners are called when the cursor's position changes.
+     * Adds a position listener to this WorldWindow. Position listeners are called when the cursor's position changes.
      * They identify the position of the cursor on the globe, or that the cursor is not on the globe.
      *
      * @param listener The position listener to add.
@@ -138,21 +138,21 @@ public interface WorldWindow extends AVList
     void addPositionListener(PositionListener listener);
 
     /**
-     * Removes the specified position listener associated with this world window.
+     * Removes the specified position listener associated with this WorldWindow.
      *
      * @param listener The listener to remove.
      */
     void removePositionListener(PositionListener listener);
 
     /**
-     * Causes a repaint event to be enqueued with the window system for this world window. The repaint will occur at the
+     * Causes a repaint event to be enqueued with the window system for this WorldWindow. The repaint will occur at the
      * window system's discretion, within the window system toolkit's event loop, and on the thread of that loop. This
-     * is the preferred method for requesting a repaint of the world window.
+     * is the preferred method for requesting a repaint of the WorldWindow.
      */
     void redraw();
 
     /**
-     * Immediately repaints the world window without waiting for a window system repaint event. This is not the
+     * Immediately repaints the WorldWindow without waiting for a window system repaint event. This is not the
      * preferred way to cause a repaint, but is provided for the rare cases that require it.
      */
     void redrawNow();
@@ -166,8 +166,8 @@ public interface WorldWindow extends AVList
     Position getCurrentPosition();
 
     /**
-     * Returns the World Wind objects at the current cursor position. The list of objects under the cursor is determined
-     * each time the world window is repainted. This method returns the list of objects determined when the most recent
+     * Returns the WorldWind objects at the current cursor position. The list of objects under the cursor is determined
+     * each time the WorldWindow is repainted. This method returns the list of objects determined when the most recent
      * repaint was performed.
      *
      * @return The list of objects at the cursor position, or <code>null</code> if no objects are under the cursor.
@@ -175,8 +175,8 @@ public interface WorldWindow extends AVList
     PickedObjectList getObjectsAtCurrentPosition();
 
     /**
-     * Returns the World Wind objects intersecting the current selection box. The list of objects in the selection box
-     * is determined each time the world window  is repainted. This method returns the list of objects determined when
+     * Returns the WorldWind objects intersecting the current selection box. The list of objects in the selection box
+     * is determined each time the WorldWindow  is repainted. This method returns the list of objects determined when
      * the most recent repaint was performed.
      *
      * @return The list of objects intersecting the selection box, or <code>null</code> if no objects are in the box.
@@ -184,14 +184,14 @@ public interface WorldWindow extends AVList
     PickedObjectList getObjectsInSelectionBox();
 
     /**
-     * Returns the GPU Resource used by this World Window. This method is for internal use only.
+     * Returns the GPU Resource used by this WorldWindow. This method is for internal use only.
      * <p/>
      * Note: Applications do not need to interact with the GPU resource cache. It is self managed. Modifying it in any
      * way will cause significant problems such as excessive memory usage or application crashes. The only reason to use
      * the GPU resource cache is to request management of GPU resources within implementations of shapes or layers. And
      * then access should be only through the draw context only.
      *
-     * @return The GPU Resource cache used by this World Window.
+     * @return The GPU Resource cache used by this WorldWindow.
      */
     GpuResourceCache getGpuResourceCache();
 
@@ -211,13 +211,13 @@ public interface WorldWindow extends AVList
     Collection<PerformanceStatistic> getPerFrameStatistics(); // TODO: move the constants from AVKey to this interface.
 
     /**
-     * Causes resources used by the World Window to be freed. The World Window cannot be used once this method is
+     * Causes resources used by the WorldWindow to be freed. The WorldWindow cannot be used once this method is
      * called.
      */
     void shutdown();
 
     /**
-     * Adds an exception listener to this world window. Exception listeners are called when an exception or other
+     * Adds an exception listener to this WorldWindow. Exception listeners are called when an exception or other
      * critical event occurs during drawable initialization or during rendering.
      *
      * @param listener the The exception listener to add.
@@ -225,7 +225,7 @@ public interface WorldWindow extends AVList
     void addRenderingExceptionListener(RenderingExceptionListener listener);
 
     /**
-     * Removes the specified rendering exception listener associated with this world window.
+     * Removes the specified rendering exception listener associated with this WorldWindow.
      *
      * @param listener The listener to remove.
      */

--- a/src/gov/nasa/worldwind/WorldWindowGLAutoDrawable.java
+++ b/src/gov/nasa/worldwind/WorldWindowGLAutoDrawable.java
@@ -27,7 +27,7 @@ import java.util.logging.Level;
 
 /**
  * A non-platform specific {@link WorldWindow} class. This class can be aggregated into platform-specific classes to
- * provide the core functionality of World Wind.
+ * provide the core functionality of WorldWind.
  *
  * @author Tom Gaskins
  * @version $Id: WorldWindowGLAutoDrawable.java 2047 2014-06-06 22:48:33Z tgaskins $
@@ -236,7 +236,7 @@ public class WorldWindowGLAutoDrawable extends WorldWindowImpl implements WorldW
         // 1) As of November 2012, we cannot find any evidence that the GL_ARB_texture_non_power_of_two extension is
         //    problematic on Mac OS X machines with ATI graphics cards. The texture rectangle extension is more limiting
         //    than the NPOT extension, and therefore not preferred.
-        // 2) World Wind assumes that a texture's target is always GL_TEXTURE_2D, and therefore incorrectly displays
+        // 2) WorldWind assumes that a texture's target is always GL_TEXTURE_2D, and therefore incorrectly displays
         //    textures with the target GL_TEXTURE_RECTANGLE.
         TextureIO.setTexRectEnabled(false);
 
@@ -263,7 +263,7 @@ public class WorldWindowGLAutoDrawable extends WorldWindowImpl implements WorldW
      * <ul> <li>The WorldWindow is removed from its parent component.</li> <li>The WorldWindow's parent frame is
      * closed.</li> <li>The application calls either GLCanvas.dispose or GLJPanel.dispose.</li> </ul>
      * <p/>
-     * This implementation is left empty. In the case when a WorldWindow or a World Wind application has reached its end
+     * This implementation is left empty. In the case when a WorldWindow or a WorldWind application has reached its end
      * of life, its resources should be released by calling {@link gov.nasa.worldwind.WorldWindow#shutdown()} or {@link
      * gov.nasa.worldwind.WorldWind#shutDown()}, respectively. In the case when a WorldWindow is removed from its parent
      * frame or that frame is closed without a call to shutdown, it is assumed that the application intends to reuse the

--- a/src/gov/nasa/worldwind/WorldWindowImpl.java
+++ b/src/gov/nasa/worldwind/WorldWindowImpl.java
@@ -42,7 +42,7 @@ public abstract class WorldWindowImpl extends WWObjectImpl implements WorldWindo
     }
 
     /**
-     * Causes resources used by the World Window to be freed. The World Window cannot be used once this method is
+     * Causes resources used by the WorldWindow to be freed. The WorldWindow cannot be used once this method is
      * called. An OpenGL context for the window must be current.
      */
     public void shutdown()

--- a/src/gov/nasa/worldwind/avlist/AVKey.java
+++ b/src/gov/nasa/worldwind/avlist/AVKey.java
@@ -85,7 +85,7 @@ public interface AVKey // TODO: Eliminate unused constants, if any
     final String DATA_TYPE = "gov.nasa.worldwind.avkey.DataType";
     final String DELETE_CACHE_ON_EXIT = "gov.nasa.worldwind.avkey.DeleteCacheOnExit";
     /**
-     * Indicates the World Wind scene's worst-case depth resolution, in meters. This is typically interpreted by the
+     * Indicates the WorldWind scene's worst-case depth resolution, in meters. This is typically interpreted by the
      * View as the desired resolution at the scene's maximum drawing distance. In this case, the resolution closer to
      * the viewer's eye point is significantly better then the worst-case resolution. Decreasing this value enables the
      * viewer to get closer to 3D shapes positioned above the terrain at the coast of potential rendering artifacts

--- a/src/gov/nasa/worldwind/awt/AWTInputHandler.java
+++ b/src/gov/nasa/worldwind/awt/AWTInputHandler.java
@@ -372,7 +372,7 @@ public class AWTInputHandler extends WWObjectImpl
         }
 
         // Determine if the mouse point has changed since the last mouse move event. This can happen if user switches to
-        // another window, moves the mouse, and then switches back to the World Wind window.
+        // another window, moves the mouse, and then switches back to the WorldWind window.
         boolean mousePointChanged = !mouseEvent.getPoint().equals(this.mousePoint);
 
         this.mousePoint = mouseEvent.getPoint();

--- a/src/gov/nasa/worldwind/awt/AbstractViewInputHandler.java
+++ b/src/gov/nasa/worldwind/awt/AbstractViewInputHandler.java
@@ -657,7 +657,7 @@ public abstract class AbstractViewInputHandler implements ViewInputHandler, java
 
     public void apply()
     {
-        // Process per-frame input only when the World Window is the focus owner.
+        // Process per-frame input only when the WorldWindow is the focus owner.
         if (!this.isWorldWindowFocusOwner())
         {
             return;

--- a/src/gov/nasa/worldwind/awt/WorldWindowGLCanvas.java
+++ b/src/gov/nasa/worldwind/awt/WorldWindowGLCanvas.java
@@ -21,7 +21,7 @@ import java.beans.*;
 import java.util.*;
 
 /**
- * <code>WorldWindowGLCanvas</code> is a heavyweight AWT component for displaying World Wind {@link Model}s (globe and
+ * <code>WorldWindowGLCanvas</code> is a heavyweight AWT component for displaying WorldWind {@link Model}s (globe and
  * layers). It's a self-contained component intended to serve as an application's <code>WorldWindow</code>. Construction
  * options exist to specify a specific graphics device and to share graphics resources with another graphics device.
  * <p/>
@@ -35,14 +35,14 @@ import java.util.*;
  * This class is capable of supporting stereo devices. To cause a stereo device to be selected and used, specify the
  * Java VM property "gov.nasa.worldwind.stereo.mode=device" prior to creating an instance of this class. A stereo
  * capable {@link SceneController} such as {@link gov.nasa.worldwind.StereoSceneController} must also be specified in
- * the World Wind {@link Configuration}. The default configuration specifies a stereo-capable controller. To prevent
+ * the WorldWind {@link Configuration}. The default configuration specifies a stereo-capable controller. To prevent
  * stereo from being used by subsequently opened {@code WorldWindowGLCanvas}es, set the property to a an empty string,
- * "". If a stereo device cannot be selected and used, this falls back to a non-stereo device that supports World Wind's
+ * "". If a stereo device cannot be selected and used, this falls back to a non-stereo device that supports WorldWind's
  * minimum requirements.
  * <p/>
  * Under certain conditions, JOGL replaces the <code>GLContext</code> associated with instances of this class. This then
  * necessitates that all resources such as textures that have been stored on the graphic devices must be regenerated for
- * the new context. World Wind does this automatically by clearing the associated {@link GpuResourceCache}. Objects
+ * the new context. WorldWind does this automatically by clearing the associated {@link GpuResourceCache}. Objects
  * subsequently rendered automatically re-create those resources. If an application creates its own graphics resources,
  * including textures, vertex buffer objects and display lists, it must store them in the <code>GpuResourceCache</code>
  * associated with the current {@link gov.nasa.worldwind.render.DrawContext} so that they are automatically cleared, and

--- a/src/gov/nasa/worldwind/awt/WorldWindowGLJPanel.java
+++ b/src/gov/nasa/worldwind/awt/WorldWindowGLJPanel.java
@@ -20,7 +20,7 @@ import java.beans.*;
 import java.util.*;
 
 /**
- * <code>WorldWindowGLCanvas</code> is a lightweight Swing component for displaying World Wind {@link Model}s (globe and
+ * <code>WorldWindowGLCanvas</code> is a lightweight Swing component for displaying WorldWind {@link Model}s (globe and
  * layers). It's a self-contained component intended to serve as an application's <code>WorldWindow</code>. Construction
  * options exist to specify a specific graphics device and to share graphics resources with another graphics device.
  * <p/>
@@ -34,14 +34,14 @@ import java.util.*;
  * This class is capable of supporting stereo devices. To cause a stereo device to be selected and used, specify the
  * Java VM property "gov.nasa.worldwind.stereo.mode=device" prior to creating an instance of this class. A stereo
  * capable {@link SceneController} such as {@link gov.nasa.worldwind.StereoSceneController} must also be specified in
- * the World Wind {@link Configuration}. The default configuration specifies a stereo-capable controller. To prevent
+ * the WorldWind {@link Configuration}. The default configuration specifies a stereo-capable controller. To prevent
  * stereo from being used by subsequently opened {@code WorldWindowGLCanvas}es, set the property to a an empty string,
- * "". If a stereo device cannot be selected and used, this falls back to a non-stereo device that supports World Wind's
+ * "". If a stereo device cannot be selected and used, this falls back to a non-stereo device that supports WorldWind's
  * minimum requirements.
  * <p/>
  * Under certain conditions, JOGL replaces the <code>GLContext</code> associated with instances of this class. This then
  * necessitates that all resources such as textures that have been stored on the graphic devices must be regenerated for
- * the new context. World Wind does this automatically by clearing the associated {@link GpuResourceCache}. Objects
+ * the new context. WorldWind does this automatically by clearing the associated {@link GpuResourceCache}. Objects
  * subsequently rendered automatically re-create those resources. If an application creates its own graphics resources,
  * including textures, vertex buffer objects and display lists, it must store them in the <code>GpuResourceCache</code>
  * associated with the current {@link gov.nasa.worldwind.render.DrawContext} so that they are automatically cleared, and

--- a/src/gov/nasa/worldwind/cache/AbstractFileStore.java
+++ b/src/gov/nasa/worldwind/cache/AbstractFileStore.java
@@ -612,7 +612,7 @@ public abstract class AbstractFileStore extends WWObjectImpl implements FileStor
     }
 
     /**
-     * @param url the "file:" URL of the file to remove from the file store. Only files in the writable World Wind disk
+     * @param url the "file:" URL of the file to remove from the file store. Only files in the writable WorldWind disk
      *            cache or temp file directory are removed by this method.
      *
      * @throws IllegalArgumentException if <code>url</code> is null

--- a/src/gov/nasa/worldwind/cache/BasicDataFileStore.java
+++ b/src/gov/nasa/worldwind/cache/BasicDataFileStore.java
@@ -53,13 +53,13 @@ public class BasicDataFileStore extends AbstractFileStore
      * content type returned by the server. Subsequent calls to <code>requestFile</code> use the content types in this
      * list to find the content type matching the cached file.
      * <p/>
-     * This is initialized to the following list of default content types typically used in World Wind applications:
+     * This is initialized to the following list of default content types typically used in WorldWind applications:
      * <p/>
      * <ul> <li>application/vnd.google-earth.kml+xml</li> <li>application/vnd.google-earth.kmz</li>
      * <li>model/collada+xml</li> <li>image/dds</li> <li>image/gif</li> <li>image/jpeg</li> <li>image/jpg</li>
      * <li>image/png</li> </ul>
      * <p/>
-     * This list may be overridden by specifying a comma-delimited list of content types in the World Wind configuration
+     * This list may be overridden by specifying a comma-delimited list of content types in the WorldWind configuration
      * parameter <code>gov.nasa.worldwind.avkey.CacheContentTypes</code>.
      */
     protected List<String> cacheContentTypes = new ArrayList<String>(DEFAULT_CACHE_CONTENT_TYPES);
@@ -249,7 +249,7 @@ public class BasicDataFileStore extends AbstractFileStore
             throw new IllegalStateException(message);
         }
 
-        // Store remote files in the World Wind cache by default. This provides backward compatibility with applications
+        // Store remote files in the WorldWind cache by default. This provides backward compatibility with applications
         // depending on requestFile's behavior prior to the addition of the cacheRemoteFile parameter.
         return this.requestFile(address, true);
     }
@@ -307,13 +307,13 @@ public class BasicDataFileStore extends AbstractFileStore
     /**
      * Returns a file from the cache, the local file system or the classpath if the file exists. The specified address
      * may be a jar URL. See {@link java.net.JarURLConnection} for a description of jar URLs. If
-     * <code>searchLocalCache</code> is <code>true</code> this looks for the file in the World Wind cache, otherwise
+     * <code>searchLocalCache</code> is <code>true</code> this looks for the file in the WorldWind cache, otherwise
      * this only looks for the file in the local file system and the classpath.
      *
      * @param address          the name used to identify the cached file.
      * @param retrievalUrl     the URL to obtain the file if it is not in the cache. Used only to determine a location
      *                         to search in the local cache. May be null.
-     * @param searchLocalCache <code>true</code> to look for the file in the World Wind cache, otherwise
+     * @param searchLocalCache <code>true</code> to look for the file in the WorldWind cache, otherwise
      *                         <code>false</code>.
      *
      * @return the requested file if it exists, otherwise null.
@@ -361,7 +361,7 @@ public class BasicDataFileStore extends AbstractFileStore
                 }
         }
 
-        // If the address is a file, look for the file in the classpath and World Wind disk cache. We perform this step
+        // If the address is a file, look for the file in the classpath and WorldWind disk cache. We perform this step
         // regardless of the searchLocalCache parameter, because this looks for the file in the classpath.
         // We need to ensure that the address is not a network address (HTTP, etc.) because the getResource call in
         // findFile will attempt to retrieve from that URL on the thread that called this method, which might be the EDT
@@ -369,7 +369,7 @@ public class BasicDataFileStore extends AbstractFileStore
         if (cacheFileUrl == null && (addressProtocol == null || addressProtocol.equals("file")))
             cacheFileUrl = WorldWind.getDataFileStore().findFile(address, true);
 
-        // Look for the file in the World Wind disk cache by creating a cache path from the file's address. We ignore this
+        // Look for the file in the WorldWind disk cache by creating a cache path from the file's address. We ignore this
         // step if searchLocalCache is false.
         if (cacheFileUrl == null && retrievalUrl != null && searchLocalCache)
         {

--- a/src/gov/nasa/worldwind/cache/FileStore.java
+++ b/src/gov/nasa/worldwind/cache/FileStore.java
@@ -200,7 +200,7 @@ public interface FileStore extends WWObject
      * Requests a file. If the file exists locally, including as a resource on the classpath, this returns a
      * <code>{@link URL}</code> to the file. Otherwise if the specified address is a URL to a remote location, this
      * initiates a request for the file and returns <code>null</code>. When the request succeeds the file is stored in
-     * the local World Wind cache and subsequent invocations of this method return a URL to the retrieved file.
+     * the local WorldWind cache and subsequent invocations of this method return a URL to the retrieved file.
      *
      * @param address the file address: either a local file, a URL, or a path relative to the root of the file store.
      *
@@ -215,20 +215,20 @@ public interface FileStore extends WWObject
      * Requests a file and specifies whether to store retrieved files in the cache or in a temporary location. If the
      * file exists locally, including as a resource on the classpath, this returns a <code>{@link URL}</code> to the
      * file. Otherwise if the specified address is a URL to a remote location, this initiates a request for the file and
-     * returns <code>null</code>. When the request succeeds the file is stored either in the local World Wind cache or
+     * returns <code>null</code>. When the request succeeds the file is stored either in the local WorldWind cache or
      * in a temporary location and subsequent invocations of this method return a URL to the retrieved file.
      * <p/>
-     * The <code>cacheRemoteFile</code> parameter specifies whether to store a retrieved remote file in the World Wind
+     * The <code>cacheRemoteFile</code> parameter specifies whether to store a retrieved remote file in the WorldWind
      * cache or in a temporary location. This parameter has no effect if the file exists locally. The temporary location
      * for a retrieved file does not persist between runtime sessions, and subsequent invocations of this method may not
      * return the same temporary location.
      * <p/>
      * If a remote file is requested multiple times with different values for <code>cacheRemoteFile</code>, it is
-     * undefined whether the retrieved file is stored in the World Wind cache or in a temporary location.
+     * undefined whether the retrieved file is stored in the WorldWind cache or in a temporary location.
      *
      * @param address         the file address: either a local file, a URL, or a path relative to the root of the file
      *                        store.
-     * @param cacheRemoteFile <code>true</code> to store remote files in the World Wind cache, or <code>false</code> to
+     * @param cacheRemoteFile <code>true</code> to store remote files in the WorldWind cache, or <code>false</code> to
      *                        store remote files in a temporary location. Has no effect if the address is a local file.
      *
      * @return the file's URL if it exists locally or is a remote file that has been retrieved, otherwise

--- a/src/gov/nasa/worldwind/data/BasicDataRasterReaderFactory.java
+++ b/src/gov/nasa/worldwind/data/BasicDataRasterReaderFactory.java
@@ -23,7 +23,7 @@ import gov.nasa.worldwind.util.Logging;
  * </pre>
  * <p/>
  * To specify a different factory, set the {@link gov.nasa.worldwind.avlist.AVKey#DATA_RASTER_READER_FACTORY_CLASS_NAME}
- * value in {@link gov.nasa.worldwind.Configuration}, either directly or via the World Wind configuration file. To add
+ * value in {@link gov.nasa.worldwind.Configuration}, either directly or via the WorldWind configuration file. To add
  * readers to the default set, create a subclass of this class, override {@link #findReaderFor(Object,
  * gov.nasa.worldwind.avlist.AVList)}, and specify the new class to the configuration.
  *

--- a/src/gov/nasa/worldwind/data/package.html
+++ b/src/gov/nasa/worldwind/data/package.html
@@ -15,10 +15,10 @@
 <body>
 
 <p>
-    This package provides classes for converting raw data sources into a form which can be used by standard World Wind
+    This package provides classes for converting raw data sources into a form which can be used by standard WorldWind
     components, such as {@link gov.nasa.worldwind.layers.Layer} and {@link gov.nasa.worldwind.globes.ElevationModel}.
     The gov.nasa.worldwind.data package contains two key interfaces: DataRaster, and DataStoreProducer. Older versions
-    of the gov.nasa.worldwind.data package included DataDescriptor, which has been removed from World Wind. This section
+    of the gov.nasa.worldwind.data package included DataDescriptor, which has been removed from WorldWind. This section
     describes the role of each interface. A guide to updating code which uses DataDescriptor can be found
     <a href="#Section_DataDescriptorPortingGuide">here</a>.
 
@@ -51,21 +51,21 @@
 
 <p>
     {@link gov.nasa.worldwind.data.DataStoreProducer} provides a common interface for converting raw data sources into a
-    form which can be used by standard World Wind components. There are three concrete implementations of
+    form which can be used by standard WorldWind components. There are three concrete implementations of
     DataStoreProducer:
 <ul>
-    <li>{@link gov.nasa.worldwind.data.TiledElevationProducer} - converts georeferenced image files into the World Wind
+    <li>{@link gov.nasa.worldwind.data.TiledElevationProducer} - converts georeferenced image files into the WorldWind
         tile cache structure, which can be rendered on the globe by a {@link gov.nasa.worldwind.layers.TiledImageLayer}.
         </li>
     <li>{@link gov.nasa.worldwind.data.TiledImageProducer} - converts georeferenced elevation data files into the World
         Wind tile cache structure, which can become part of the globe's surface terrain by using a
         {@link gov.nasa.worldwind.terrain.BasicElevationModel}.</li>
-    <li>{@link gov.nasa.worldwind.data.WWDotNetLayerSetConverter} - converts data in the World Wind .NET tile cache
-        structure into the World Wind Java tile cache structure.</li>
+    <li>{@link gov.nasa.worldwind.data.WWDotNetLayerSetConverter} - converts data in the WorldWind .NET tile cache
+        structure into the WorldWind Java tile cache structure.</li>
 </ul>
 
 <p>
-    <strong>Data Configuration Documents</strong> are a common mechanism and file format for describing a World Wind
+    <strong>Data Configuration Documents</strong> are a common mechanism and file format for describing a WorldWind
     component's configuration. While data configuration documents are not part of the gov.nasa.worldwind.data package,
     they are used as a configuration exchange mechanism by the classes in gov.nasa.worldwind.data. For example,
     DataStoreProducer returns a DOM Document describing the data it produces. Understanding how to use data
@@ -74,7 +74,7 @@
     configuration documents to manage the data produced by classes in this package.
 
 <p>
-    <strong>DataDescriptor</strong> defined an interface for representing meta information about World Wind cache data.
+    <strong>DataDescriptor</strong> defined an interface for representing meta information about WorldWind cache data.
     It has been replaced with data configuration documents, which provide a common mechanism to describe a component's
     configuration. For information how to update code which uses DataDescriptor, see the
     <a href="#Section_DataDescriptorPortingGuide">DataDescriptor Porting Guide</a>.
@@ -266,9 +266,9 @@
 <!--********************  Deploying GDAL Libraries  **************-->
 <!--**************************************************************-->
 
-<h2>Deploying World Wind's GDAL Libraries</h2>
+<h2>Deploying WorldWind's GDAL Libraries</h2>
 
-    The open-source GDAL and PROJ4 libraries are used to import many of World Wind's supported data formats. World Wind
+    The open-source GDAL and PROJ4 libraries are used to import many of WorldWind's supported data formats. WorldWind
     uses GDAL version 1.7.2 and PROJ4 version ?.? along with LizardTech's Decode SDK version 7.0.0.2167 for MrSID
     support.
     <!--TODO: fill in PROJ4 version number above-->
@@ -290,14 +290,14 @@
     <li>Windows 64bit library <code>gdalalljni.dll</code> is located in <code>lib-external/gdal/win64/</code></li>
     <li>Mac OSX library <code>libgdalalljni.jnilib</code> is in <code>lib-external/gdal/macosx/</code></li>
 </ul>
-    The GDAL and PROJ4 libraries require data tables located in <code>lib-external/gdal/data</code>. World Wind attempts
-    to locate GDAL libraries during startup. By default World Wind will first look in the locations listed above, then
+    The GDAL and PROJ4 libraries require data tables located in <code>lib-external/gdal/data</code>. WorldWind attempts
+    to locate GDAL libraries during startup. By default WorldWind will first look in the locations listed above, then
     in the current path, and if no GDAL bundle was found, will try to locate the GDAL bundle in the sub-folders.
     <!--TODO: which sub-folders?-->
 
 <h3>Deploying with Java Web Start</h3>
 
-    Instructions for using the World Wind GDAL libraries with a Java Web Start application are available at
+    Instructions for using the WorldWind GDAL libraries with a Java Web Start application are available at
     <a href="https://goworldwind.org/getting-started/" target="_blank">https://goworldwind.org/getting-started/</a>.
 
 <!--**************************************************************-->
@@ -309,17 +309,17 @@
     The following examples demonstrate the most common use cases which the classes in gov.nasa.worldwind.data are
     designed to address. Additionally, several examples demonstrate data management use cases using data configuration
     documents. These examples constitute an overview of how to convert raw data sources into a form which can be
-    consumed by World Wind components, then manage the data in its converted form.
+    consumed by WorldWind components, then manage the data in its converted form.
 
 <!-- Example 1 -->
 <p>
-    <strong><a name="Example_1">Example 1: Converting Georeferenced Imagery to the World Wind Tile Structure</a>
+    <strong><a name="Example_1">Example 1: Converting Georeferenced Imagery to the WorldWind Tile Structure</a>
     </strong>
     <blockquote>
     <pre>
     <code>
     // Given a source image, and a path to a folder in the local file system which receives the image tiles, configure a
-    // TiledImageProducer to create a pyramid of images tiles in the World Wind Java cache format.
+    // TiledImageProducer to create a pyramid of images tiles in the WorldWind Java cache format.
     String imagePath = ...;
     String tiledImagePath = ...;
     String tiledImageDisplayName = ...;
@@ -330,7 +330,7 @@
     params.setValue(AVKey.DATA_CACHE_NAME, WWIO.getFilename(tiledImagePath));
     params.setValue(AVKey.DATASET_NAME, tiledImageDisplayName);
 
-    // Create a TiledImageProducer to transform the source image to a pyramid of images tiles in the World Wind
+    // Create a TiledImageProducer to transform the source image to a pyramid of images tiles in the WorldWind
     // Java cache format.
     DataStoreProducer producer = new TiledImageProducer();
     try
@@ -338,7 +338,7 @@
         // Configure the TiledImageProducer with the parameter list and the image source.
         producer.setStoreParameters(params);
         producer.offerDataSource(new File(imagePath), null);
-        // Import the source image into the FileStore by converting it to the World Wind Java cache format. This throws
+        // Import the source image into the FileStore by converting it to the WorldWind Java cache format. This throws
         // an exception if production fails for any reason.
         producer.startProduction();
     }
@@ -366,21 +366,21 @@
 
 <!-- Example 2 -->
 <p>
-    <strong><a name="Example_2">Example 2: Converting Georeferenced Elevation Data to the World Wind Tile Structure</a>
+    <strong><a name="Example_2">Example 2: Converting Georeferenced Elevation Data to the WorldWind Tile Structure</a>
     </strong>
     <blockquote>
     Converting georeferenced elevation data can be accomplished by referring to
-    <a href="#Example_1">Example 1: Converting Georeferenced Imagery to the World Wind Tile Structure</a>, and replacing
+    <a href="#Example_1">Example 1: Converting Georeferenced Imagery to the WorldWind Tile Structure</a>, and replacing
     {@link gov.nasa.worldwind.data.TiledImageProducer} with {@link gov.nasa.worldwind.data.TiledElevationProducer}.
     </blockquote>
 
 <!-- Example 3 -->
 <p>
-    <strong><a name="Example_3">Example 3: Converting World Wind .NET LayerSets to the World Wind Java Tile Structure
+    <strong><a name="Example_3">Example 3: Converting WorldWind .NET LayerSets to the WorldWind Java Tile Structure
     </a></strong>
     <blockquote>
-    Converting World Wind .NET LayerSets can be accomplished by referring to
-    <a href="#Example_1">Example 1: Converting Georeferenced Imagery to the World Wind Tile Structure</a>, and replacing
+    Converting WorldWind .NET LayerSets can be accomplished by referring to
+    <a href="#Example_1">Example 1: Converting Georeferenced Imagery to the WorldWind Tile Structure</a>, and replacing
     {@link gov.nasa.worldwind.data.TiledImageProducer} with {@link gov.nasa.worldwind.data.WWDotNetLayerSetConverter}.
     </blockquote>
 
@@ -391,7 +391,7 @@
     <pre>
     <code>
     // Given a string path to a data configuration file in the local file system, read the file as a DOM document, which
-    // can be consumed by World Wind's Layer and ElevationModel factories. This code is backward compatible with
+    // can be consumed by WorldWind's Layer and ElevationModel factories. This code is backward compatible with
     // DataDescriptor files. The method DataConfigurationUtils.convertToStandardDataConfigDocument automatically detects
     // and transforms DataDescriptor documents into standard Layer and ElevationModel configuration documents.
     String dataConfigPath = ...;
@@ -403,13 +403,13 @@
 
 <!-- Example 5 -->
 <p>
-    <strong><a name="Example_5">Example 5: Reading Data Configuration Documents from the World Wind FileStore</a>
+    <strong><a name="Example_5">Example 5: Reading Data Configuration Documents from the WorldWind FileStore</a>
     </strong>
     <blockquote>
     <pre>
     <code>
-    // Given a path to a data configuration file in the World Wind FileStore, read the file as a DOM document, which can
-    // be consumed by World Wind's Layer and ElevationModel factories. This code is backward compatible with
+    // Given a path to a data configuration file in the WorldWind FileStore, read the file as a DOM document, which can
+    // be consumed by WorldWind's Layer and ElevationModel factories. This code is backward compatible with
     // DataDescriptor files. The method DataConfigurationUtils.convertToStandardDataConfigDocument automatically detects
     // and transforms DataDescriptor documents into standard Layer or ElevationModel configuration documents.
     FileStore fileStore = ...;
@@ -457,7 +457,7 @@
     }
     else
     {
-        // Otherwise, you'll need to create your own document. World Wind currently provides support for creating data
+        // Otherwise, you'll need to create your own document. WorldWind currently provides support for creating data
         // configuration files for tiled imagery and tiled elevations. Write custom code to create a data configuration
         // document which corresponds with your data. Use LayerConfiguration and ElevationModelConfiguration as
         // references, and use the methods in WWXML to construct your document in memory.
@@ -479,7 +479,7 @@
     // representing the matches closest to the root: data configuration files who's ancestor directories contain another
     // data configuration file are ignored. The search path cannot be null. This code is backward compatible with
     // DataDescriptor files. The class DataConfigurationFilter accepts standard Layer and ElevationModel configuration
-    // files, DataDescriptor files, and World Wind .NET LayerSet files.
+    // files, DataDescriptor files, and WorldWind .NET LayerSet files.
     String searchPath = ...;
     String[] filePaths = WWIO.listDescendantFilenames(searchPath, new DataConfigurationFilter());
 
@@ -494,10 +494,10 @@
 
 <!-- Example 8 -->
 <p>
-    <strong><a name="Example_8">Example 8: Searching for Data Configuration Documents in the World Wind FileStore</a>
+    <strong><a name="Example_8">Example 8: Searching for Data Configuration Documents in the WorldWind FileStore</a>
     </strong>
     <blockquote>
-    There are two methods of searching for data configuration files in the World Wind FileStore. The first method
+    There are two methods of searching for data configuration files in the WorldWind FileStore. The first method
     individually searches each FileStore location using the method
     {@link gov.nasa.worldwind.util.WWIO#listDescendantFilenames(java.io.File, java.io.FileFilter, boolean)}. This method
     is equivalent to calling the method <code>FileStore.findDataDescriptors(String)</code> (which has been removed), and
@@ -505,11 +505,11 @@
     the FileStore locations it searches for data configuration files.
     <pre>
     <code>
-    // Given a World Wind FileStore location in which to look for data configuration files, return a list of cache names
+    // Given a WorldWind FileStore location in which to look for data configuration files, return a list of cache names
     // representing the matches closest to the root: data configuration files who's ancestor directories contain another
     // data configuration file are ignored. This code is backward compatible with DataDescriptor files. The class
     // DataConfigurationFilter accepts standard Layer and ElevationModel configuration files, DataDescriptor files, and
-    // World Wind .NET LayerSet files.
+    // WorldWind .NET LayerSet files.
     String fileStoreLocation = ...;
     String[] cacheNames = WWIO.listDescendantFilenames(fileStoreLocation, new DataConfigurationFilter(), false);
 
@@ -520,17 +520,17 @@
     }
     </code>
     </pre>
-    The second method searches the entire World Wind FileStore under a relative file store path. Use this method when
+    The second method searches the entire WorldWind FileStore under a relative file store path. Use this method when
     your application doesn't care which FileStore location it searches for data configuration files, but may care what
     relative file store path it searches under.
     <pre>
     <code>
-    // Given a search path in the World Wind FileStore to look for data configuration files, return a list of cache
+    // Given a search path in the WorldWind FileStore to look for data configuration files, return a list of cache
     // names representing the matches closest to the root: data configuration files who's ancestor directories contain
     // another data configuration file are ignored. If the search path is null, the method FileStore.listTopFileNames
     // searches the entire FileStore, excluding the class path. This code is backward compatible with DataDescriptor
     // files. The class DataConfigurationFilter accepts standard Layer and ElevationModel configuration files,
-    // DataDescriptor files, and World Wind .NET LayerSet files.
+    // DataDescriptor files, and WorldWind .NET LayerSet files.
     FileStore fileStore = ...;
     String fileStoreSearchPath = ...;
     String[] cacheNames = fileStore.listTopFileNames(fileStoreSearchPath, new DataConfigurationFilter());
@@ -546,17 +546,17 @@
 
 <!-- Example 9 -->
 <p>
-    <strong><a name="Example_9">Example 9: Creating World Wind Components from Data Configuration Documents</a></strong>
+    <strong><a name="Example_9">Example 9: Creating WorldWind Components from Data Configuration Documents</a></strong>
     <blockquote>
     <pre>
     <code>
-    // Given a data configuration document which describes tiled imagery or tiled elevations in the World Wind
-    // FileStore, create a World Wind Layer or ElevationModel according to the contents of the data configuration
+    // Given a data configuration document which describes tiled imagery or tiled elevations in the WorldWind
+    // FileStore, create a WorldWind Layer or ElevationModel according to the contents of the data configuration
     // document. This code is backward compatible with DataDescriptor files if the data configuration file was opened as
     // shown in <a href="#Example_5">Example 5</a> or <a href="#Example_8">Example 8</a>.
     Document dataConfigDoc = ...;
     AVList params = ...;
-    String filename = ...; // The data configuration's filename, relative to a World Wind file store.
+    String filename = ...; // The data configuration's filename, relative to a WorldWind file store.
 
     // If the data configuration doesn't define a cache name, then compute one using the file's path relative to its
     // file store directory.
@@ -583,7 +583,7 @@
     }
     else
     {
-        // Currently, World Wind supports factory construction of Layers and ElevationModels from data configuration
+        // Currently, WorldWind supports factory construction of Layers and ElevationModels from data configuration
         // documents. If your data configuration document describes another type of component, you'll need to write your
         // own construction routine. Use BasicLayerFactory and BasicElevationModelFactory as references.
         return;
@@ -606,10 +606,10 @@
     <br/>
     Older versions of the gov.nasa.worldwind.data package included the DataDescriptor interface, along with its
     associated DataDescriptorReader and DataDescriptorWriter. DataDescriptor defined an interface and an XML file format
-    for representing meta information about World Wind cache data. The XML files were called "data descriptor" files,
+    for representing meta information about WorldWind cache data. The XML files were called "data descriptor" files,
     and were typically named "dataDescriptor.xml". Applications used these files to discover processed data in the World
     Wind file store, create an in-memory DataDescriptor from the file, then create either a Layer or an ElevationModel
-    from the DataDescriptor. World Wind needed a common mechanism to describe a component's configuration, but
+    from the DataDescriptor. WorldWind needed a common mechanism to describe a component's configuration, but
     DataDescriptor had two problems which prevented its use as a common mechanism: (1) it presented all information as a
     flat list of key-value pairs, making it difficult to represent heirarchical information, and (2) it decoded complex
     properties (for example lists, angles, colors) at read time based on the property name, making it impossible to
@@ -622,7 +622,7 @@
     <strong>Backward Compatibility with Data Configuration Documents</strong>
     <br/>
     Data configuration documents have supporting utilities which are designed to read and transform DataDescriptor files
-    written by older versions of World Wind. Applications which port usage of DataDescriptor to data configuration
+    written by older versions of WorldWind. Applications which port usage of DataDescriptor to data configuration
     documents can maintain backwards compatibility with the DataDescriptor files written by older versions of World
     Wind. However, there is no mechanism for forward compatibililty with data configuration documents. Applications
     which still use DataDescriptor files will not be able to recognize or read data configuration files.
@@ -632,8 +632,8 @@
     configuration which are backward compatible with DataDescriptor. <a href="#Example_4">Example 4</a> and
     <a href="#Example_5">Example 5</a> demonstrate how to read both data configuration files and DataDescriptor files.
     <a href="#Example_7">Example 7</a> and <a href="#Example_8">Example 8</a> demonstrate how to search for
-    data configuration files and DataDescriptor files in the file system or the World Wind FileStore.
-    <a href="#Example_9">Example 9</a> demonstrates how to create a World Wind Layer or ElevationModel from a
+    data configuration files and DataDescriptor files in the file system or the WorldWind FileStore.
+    <a href="#Example_9">Example 9</a> demonstrates how to create a WorldWind Layer or ElevationModel from a
     data configuration file, in a way which is backward compatible with DataDescriptor files.
     <p>
     The data configuration files created in <a href="#Example_1">Example 1</a>, <a href="#Example_2">Example 2</a>, and
@@ -645,8 +645,8 @@
     <strong>Updating Usage of DataDescriptor</strong>
     <br/>
     Data configuration documents are designed to replace DataDescriptor as a mechanism for communicating configuration
-    metadata about World Wind components. World Wind provides utilities to read and write data configuration files,
-    search for data configuration files in the local file system or World Wind file store, and create World Wind
+    metadata about WorldWind components. WorldWind provides utilities to read and write data configuration files,
+    search for data configuration files in the local file system or WorldWind file store, and create WorldWind
     components from a data configuration document. The following section outlines how to replace usage of DataDescriptor
     with data configuration files.
 <ul>
@@ -726,15 +726,15 @@
         </pre>
         </blockquote>
     </li>
-    <li><strong>Searching for DataDescriptor Files in the World Wind FileStore</strong>
+    <li><strong>Searching for DataDescriptor Files in the WorldWind FileStore</strong>
         <br/>
         The following code snippet is an example of how FileStore.findDataDescriptors was used to search for
-        DataDescriptor files in the World Wind FileStore. <a href="#Example_8">Example 8</a> shows how to replace this
+        DataDescriptor files in the WorldWind FileStore. <a href="#Example_8">Example 8</a> shows how to replace this
         with usage of data configuration documents.
         <blockquote>
         <pre>
         <code>
-        // Given a World Wind FileStore location in which to look for DataDescriptor files, return a list of cache names
+        // Given a WorldWind FileStore location in which to look for DataDescriptor files, return a list of cache names
         // representing the matches closest to the root: DataDescriptor files who's ancestor directories contain another
         // DataDescriptor file are ignored. The search location must not be null.
         String fileStoreLocation = ...;
@@ -750,16 +750,16 @@
         </pre>
         </blockquote>
     </li>
-    <li><strong>Creating World Wind Components from DataDescriptor</strong>
+    <li><strong>Creating WorldWind Components from DataDescriptor</strong>
         <br/>
         The following code snippet is an example of how the AVList parameters attached to DataDescriptor were used to
-        construct World Wind Layers and ElevationModels. <a href="#Example_9">Example 9</a> shows how to replace this
+        construct WorldWind Layers and ElevationModels. <a href="#Example_9">Example 9</a> shows how to replace this
         with usage of data configuration documents.
         <blockquote>
         <pre>
         <code>
-        // Given a reference to a DataDescriptor which describes tiled imagery or elevations in the World Wind
-        // FileStore, create a World Wind Layer or ElevationModel according to the contents of the DataDescriptor.
+        // Given a reference to a DataDescriptor which describes tiled imagery or elevations in the WorldWind
+        // FileStore, create a WorldWind Layer or ElevationModel according to the contents of the DataDescriptor.
         DataDescriptor dataDescriptor = ...;
 
         if (dataDescriptor.getType().equals(AVKey.TILED_IMAGERY))

--- a/src/gov/nasa/worldwind/event/SelectEvent.java
+++ b/src/gov/nasa/worldwind/event/SelectEvent.java
@@ -19,13 +19,13 @@ import java.util.List;
  * Select event listeners are registered by calling {@link gov.nasa.worldwind.WorldWindow#addSelectListener(SelectListener)}.
  * <p/>
  * A <code>ROLLOVER</code> SelectEvent is generated every frame when the cursor is over a visible object either because
- * the user moved it there or because the World Window was repainted and a visible object was found to be under the
+ * the user moved it there or because the WorldWindow was repainted and a visible object was found to be under the
  * cursor. A <code>ROLLOVER</code> SelectEvent is also generated when there are no longer any objects under the cursor.
  * Select events generated for objects under the cursor have a non-null pickPoint, and contain the top-most visible
  * object of all objects at the cursor position.
  * <p/>
  * A <code>BOX_ROLLOVER</code> SelectEvent is generated every frame when the selection box intersects a visible object
- * either because the user moved or expanded it or because the World Window was repainted and a visible object was found
+ * either because the user moved or expanded it or because the WorldWindow was repainted and a visible object was found
  * to intersect the box. A <code>BOX_ROLLOVER</code> SelectEvent is also generated when there are no longer any objects
  * intersecting the selection box. Select events generated for objects intersecting the selection box have a non-null
  * pickRectangle, and contain all top-most visible objects of all objects intersecting the selection box.

--- a/src/gov/nasa/worldwind/event/WWEvent.java
+++ b/src/gov/nasa/worldwind/event/WWEvent.java
@@ -8,7 +8,7 @@ package gov.nasa.worldwind.event;
 import java.util.EventObject;
 
 /**
- * WWEvent is the base class which all World Wind event objects derive from. It extends Java's base {@link
+ * WWEvent is the base class which all WorldWind event objects derive from. It extends Java's base {@link
  * java.util.EventObject} by adding the capability to consume the event by calling {@link #consume()}. Consuming a
  * WWEvent prevents is from being processed in the default manner by the source that originated the event. If the event
  * cannot be consumed, calling {@code consume()} has no effect, though {@link #isConsumed()} returns whether or not

--- a/src/gov/nasa/worldwind/exception/WWTimeoutException.java
+++ b/src/gov/nasa/worldwind/exception/WWTimeoutException.java
@@ -7,7 +7,7 @@
 package gov.nasa.worldwind.exception;
 
 /**
- * Thrown when a World Wind operation times out.
+ * Thrown when a WorldWind operation times out.
  *
  * @author tag
  * @version $Id: WWTimeoutException.java 1171 2013-02-11 21:45:02Z dcollins $

--- a/src/gov/nasa/worldwind/formats/gpx/GpxWriter.java
+++ b/src/gov/nasa/worldwind/formats/gpx/GpxWriter.java
@@ -81,7 +81,7 @@ public class GpxWriter
 
             org.w3c.dom.Element gpx = doc.createElement("gpx");
             gpx.setAttribute("version", "1.1");
-            gpx.setAttribute("creator", "NASA World Wind");
+            gpx.setAttribute("creator", "NASA WorldWind");
             doc.appendChild(gpx);
         }
     }

--- a/src/gov/nasa/worldwind/formats/shapefile/ShapefileLayerFactory.java
+++ b/src/gov/nasa/worldwind/formats/shapefile/ShapefileLayerFactory.java
@@ -25,9 +25,9 @@ import java.util.Map;
  * <p/>
  * <h1>Shapefile Geometry Conversion</h1>
  * <p/>
- * Shapefile geometries are mapped to World Wind objects as follows:
+ * Shapefile geometries are mapped to WorldWind objects as follows:
  * <p/>
- * <table> <tr><th>Shapefile Geometry</th><th>World Wind Object</th></tr> <tr><td>Point</td><td>{@link
+ * <table> <tr><th>Shapefile Geometry</th><th>WorldWind Object</th></tr> <tr><td>Point</td><td>{@link
  * gov.nasa.worldwind.render.PointPlacemark}</td></tr> <tr><td>MultiPoint</td><td>List of {@link
  * gov.nasa.worldwind.render.PointPlacemark}</td></tr> <tr><td>Polyline</td><td>{@link
  * gov.nasa.worldwind.formats.shapefile.ShapefilePolylines}</td></tr> <tr><td>Polygon</td><td>{@link

--- a/src/gov/nasa/worldwind/formats/tiff/GeotiffWriter.java
+++ b/src/gov/nasa/worldwind/formats/tiff/GeotiffWriter.java
@@ -157,7 +157,7 @@ public class GeotiffWriter
 
     AVKey.DATA_TYPE required for elevations only; valid values: AVKey.INT16, and AVKey.FLOAT32
 
-    AVKey.VERSION optional, if missing a default will be used "NASA World Wind"
+    AVKey.VERSION optional, if missing a default will be used "NASA WorldWind"
 
     AVKey.DISPLAY_NAME, (String) optional, specifies a name of the document/image
 

--- a/src/gov/nasa/worldwind/formats/vpf/GeoSymAttributeConverter.java
+++ b/src/gov/nasa/worldwind/formats/vpf/GeoSymAttributeConverter.java
@@ -15,12 +15,12 @@ import java.util.ArrayList;
 
 /**
  * The GeoSymAttributeConverter application converts GeoSym line attributes, area attributes, and area patterns into a
- * form usable by World Wind VPF shapes. Outputs to "gsac-out" a comma-separated-value (CSV) file containing line and
+ * form usable by WorldWind VPF shapes. Outputs to "gsac-out" a comma-separated-value (CSV) file containing line and
  * area attributes for VPF line and area shapes, and PNG images containing area patterns for VPF area shapes.
  * <p/>
  * GeoSymAttributeConverter is used to build the VPF symbol JAR file <code>vpf-symbols.jar</code>. For instructions on
  * how to build <code>vpf-symbols.jar</code>, see the file <code>VPF_README.txt</code>, which is distributed in each
- * World Wind release.
+ * WorldWind release.
  * <p/>
  * <code> Usage: java -cp worldwind.jar gov.nasa.worldwind.formats.vpf.GeoSymAttributeConverter [full path to
  * "GeoSymEd2Final/GRAPHICS/CTEXT"] </code>
@@ -425,7 +425,7 @@ public class GeoSymAttributeConverter
         System.out.println("GeoSymAttributeConverter");
         System.out.println();
         System.out.println("Converts GeoSym line attributes, area attributes, and area patterns into a form usable by");
-        System.out.println("World Wind VPF shapes. Outputs to \"" + OUT_DIR + "\" a comma-separated-value file");
+        System.out.println("WorldWind VPF shapes. Outputs to \"" + OUT_DIR + "\" a comma-separated-value file");
         System.out.println("containing line and area attributes for VPF line and area shapes, and PNG files");
         System.out.println("containing area patterns for VPF area shapes.");
         System.out.println();

--- a/src/gov/nasa/worldwind/layers/BasicLayerFactory.java
+++ b/src/gov/nasa/worldwind/layers/BasicLayerFactory.java
@@ -38,7 +38,7 @@ public class BasicLayerFactory extends BasicFactory
      * For tiled image layers, this maps the <code>serviceName</code> attribute of the <code>Layer/Service</code>
      * element of the XML configuration file to the appropriate base tiled image layer type. Service types recognized
      * are: <ul> <li>"WMS" for layers that draw their data from a WMS web service.</li> <li>"WWTileService" for layers
-     * that draw their data from a World Wind tile service.</li> <li>"Offline" for layers that draw their data only from
+     * that draw their data from a WorldWind tile service.</li> <li>"Offline" for layers that draw their data only from
      * the local cache.</li> </ul>
      *
      * @param configSource the configuration source. See above for supported types.

--- a/src/gov/nasa/worldwind/layers/BasicTiledImageLayer.java
+++ b/src/gov/nasa/worldwind/layers/BasicTiledImageLayer.java
@@ -400,7 +400,7 @@ public class BasicTiledImageLayer extends TiledImageLayer implements BulkRetriev
 
     /**
      * Start a new {@link BulkRetrievalThread} that downloads all imagery for a given sector and resolution to the
-     * current World Wind file cache, without downloading imagery that is already in the cache.
+     * current WorldWind file cache, without downloading imagery that is already in the cache.
      * <p/>
      * This method creates and starts a thread to perform the download. A reference to the thread is returned. To create
      * a downloader that has not been started, construct a {@link BasicTiledImageLayerBulkDownloader}.
@@ -435,7 +435,7 @@ public class BasicTiledImageLayer extends TiledImageLayer implements BulkRetriev
      *
      * @param sector     the sector to download data for.
      * @param resolution the target resolution, provided in radians of latitude per texel.
-     * @param fileStore  the file store in which to place the downloaded imagery. If null the current World Wind file
+     * @param fileStore  the file store in which to place the downloaded imagery. If null the current WorldWind file
      *                   cache is used.
      * @param listener   an optional retrieval listener. May be null.
      *
@@ -460,7 +460,7 @@ public class BasicTiledImageLayer extends TiledImageLayer implements BulkRetriev
     }
 
     /**
-     * Get the estimated size in bytes of the imagery not in the World Wind file cache for the given sector and
+     * Get the estimated size in bytes of the imagery not in the WorldWind file cache for the given sector and
      * resolution.
      * <p/>
      * Note that the target resolution must be provided in radians of latitude per texel, which is the resolution in
@@ -487,7 +487,7 @@ public class BasicTiledImageLayer extends TiledImageLayer implements BulkRetriev
      *
      * @param sector     the sector to estimate.
      * @param resolution the target resolution, provided in radians of latitude per texel.
-     * @param fileStore  the file store to examine. If null the current World Wind file cache is used.
+     * @param fileStore  the file store to examine. If null the current WorldWind file cache is used.
      *
      * @return the estimated size in byte of the missing imagery.
      *
@@ -716,7 +716,7 @@ public class BasicTiledImageLayer extends TiledImageLayer implements BulkRetriev
         //
         // Note that we use the URL's String representation as the cache key. We cannot use the URL itself, because
         // the cache invokes the methods Object.hashCode() and Object.equals() on the cache key. URL's implementations
-        // of hashCode() and equals() perform blocking IO calls. World Wind does not perform blocking calls during
+        // of hashCode() and equals() perform blocking IO calls. WorldWind does not perform blocking calls during
         // rendering, and this method is likely to be called from the rendering thread.
         WMSCapabilities caps;
         if (this.isNetworkRetrievalEnabled())

--- a/src/gov/nasa/worldwind/layers/BasicTiledImageLayerBulkDownloader.java
+++ b/src/gov/nasa/worldwind/layers/BasicTiledImageLayerBulkDownloader.java
@@ -20,7 +20,7 @@ import java.nio.ByteBuffer;
 import java.util.*;
 
 /**
- * Downloads imagery not currently available in the World Wind file cache or a specified file store. The class derives
+ * Downloads imagery not currently available in the WorldWind file cache or a specified file store. The class derives
  * from {@link Thread} and is meant to operate in its own thread.
  * <p/>
  * The sector and resolution associated with the downloader are specified during construction and are final.
@@ -38,7 +38,7 @@ public class BasicTiledImageLayerBulkDownloader extends BulkRetrievalThread
     protected ArrayList<TextureTile> missingTiles;
 
     /**
-     * Constructs a downloader to retrieve imagery not currently available in the World Wind file cache.
+     * Constructs a downloader to retrieve imagery not currently available in the WorldWind file cache.
      * <p/>
      * The thread returned is not started during construction, the caller must start the thread.
      *

--- a/src/gov/nasa/worldwind/layers/CompassLayer.java
+++ b/src/gov/nasa/worldwind/layers/CompassLayer.java
@@ -161,7 +161,7 @@ public class CompassLayer extends AbstractLayer
 
     /**
      * Sets the behavior the layer uses to size the compass icon when the viewport size changes, typically when the
-     * World Wind window is resized. If the value is AVKey.RESIZE_KEEP_FIXED_SIZE, the icon size is kept to the size
+     * WorldWind window is resized. If the value is AVKey.RESIZE_KEEP_FIXED_SIZE, the icon size is kept to the size
      * specified in its image file scaled by the layer's current icon scale. If the value is AVKey.RESIZE_STRETCH, the
      * icon is resized to have a constant size relative to the current viewport size. If the viewport shrinks the icon
      * size decreases; if it expands then the icon file enlarges. The relative size is determined by the current

--- a/src/gov/nasa/worldwind/layers/CrosshairLayer.java
+++ b/src/gov/nasa/worldwind/layers/CrosshairLayer.java
@@ -150,7 +150,7 @@ public class CrosshairLayer extends AbstractLayer
 
     /**
      * Sets the behavior the layer uses to size the crosshair icon when the viewport size changes, typically when the
-     * World Wind window is resized. If the value is AVKey.RESIZE_KEEP_FIXED_SIZE, the icon size is kept to the size
+     * WorldWind window is resized. If the value is AVKey.RESIZE_KEEP_FIXED_SIZE, the icon size is kept to the size
      * specified in its image file scaled by the layer's current icon scale. If the value is AVKey.RESIZE_STRETCH, the
      * icon is resized to have a constant size relative to the current viewport size. If the viewport shrinks the icon
      * size decreases; if it expands then the icon file enlarges. The relative size is determined by the current

--- a/src/gov/nasa/worldwind/layers/TiledImageLayer.java
+++ b/src/gov/nasa/worldwind/layers/TiledImageLayer.java
@@ -291,7 +291,7 @@ public abstract class TiledImageLayer extends AbstractLayer
         Angle latOrigin = this.levels.getTileOrigin().getLatitude();
         Angle lonOrigin = this.levels.getTileOrigin().getLongitude();
 
-        // Determine the row and column offset from the common World Wind global tiling origin.
+        // Determine the row and column offset from the common WorldWind global tiling origin.
         int firstRow = Tile.computeRow(dLat, sector.getMinLatitude(), latOrigin);
         int firstCol = Tile.computeColumn(dLon, sector.getMinLongitude(), lonOrigin);
         int lastRow = Tile.computeRow(dLat, sector.getMaxLatitude(), latOrigin);
@@ -670,7 +670,7 @@ public abstract class TiledImageLayer extends AbstractLayer
     protected void setBlendingFunction(DrawContext dc)
     {
         // Set up a premultiplied-alpha blending function. Any texture read by JOGL will have alpha-premultiplied color
-        // components, as will any DDS file created by World Wind or the World Wind WMS. We'll also set up the base
+        // components, as will any DDS file created by WorldWind or the WorldWind WMS. We'll also set up the base
         // color as a premultiplied color, so that any incoming premultiplied color will be properly combined with the
         // base color.
 

--- a/src/gov/nasa/worldwind/layers/WorldMapLayer.java
+++ b/src/gov/nasa/worldwind/layers/WorldMapLayer.java
@@ -178,7 +178,7 @@ public class WorldMapLayer extends AbstractLayer
 
     /**
      * Sets the behavior the layer uses to size the world map icon when the viewport size changes, typically when the
-     * World Wind window is resized. If the value is AVKey.RESIZE_KEEP_FIXED_SIZE, the icon size is kept to the size
+     * WorldWind window is resized. If the value is AVKey.RESIZE_KEEP_FIXED_SIZE, the icon size is kept to the size
      * specified in its image file scaled by the layer's current icon scale. If the value is AVKey.RESIZE_STRETCH, the
      * icon is resized to have a constant size relative to the current viewport size. If the viewport shrinks the icon
      * size decreases; if it expands then the icon file enlarges. The relative size is determined by the current world

--- a/src/gov/nasa/worldwind/layers/mercator/MercatorTiledImageLayer.java
+++ b/src/gov/nasa/worldwind/layers/mercator/MercatorTiledImageLayer.java
@@ -201,7 +201,7 @@ public abstract class MercatorTiledImageLayer extends AbstractLayer
         Angle latOrigin = this.levels.getTileOrigin().getLatitude();
         Angle lonOrigin = this.levels.getTileOrigin().getLongitude();
 
-        // Determine the row and column offset from the common World Wind global tiling origin.
+        // Determine the row and column offset from the common WorldWind global tiling origin.
         int firstRow = Tile.computeRow(dLat, sector.getMinLatitude(), latOrigin);
         int firstCol = Tile.computeColumn(dLon, sector.getMinLongitude(), lonOrigin);
         int lastRow = Tile.computeRow(dLat, sector.getMaxLatitude(), latOrigin);

--- a/src/gov/nasa/worldwind/layers/placename/PlaceNameLayer.java
+++ b/src/gov/nasa/worldwind/layers/placename/PlaceNameLayer.java
@@ -1229,7 +1229,7 @@ public class PlaceNameLayer extends AbstractLayer implements BulkRetrievable
 
     /**
      * Start a new {@link BulkRetrievalThread} that downloads all placenames for a given sector and resolution to the
-     * current World Wind file cache.
+     * current WorldWind file cache.
      * <p/>
      * This method creates and starts a thread to perform the download. A reference to the thread is returned. To create
      * a downloader that has not been started, construct a {@link PlaceNameLayerBulkDownloader}.
@@ -1267,7 +1267,7 @@ public class PlaceNameLayer extends AbstractLayer implements BulkRetrievable
      *
      * @param sector     the sector to download data for.
      * @param resolution the target resolution, provided in radians of latitude per texel.
-     * @param fileStore  the file store in which to place the downloaded elevations. If null the current World Wind file
+     * @param fileStore  the file store in which to place the downloaded elevations. If null the current WorldWind file
      *                   cache is used.
      * @param listener   an optional retrieval listener. May be null.
      *
@@ -1287,7 +1287,7 @@ public class PlaceNameLayer extends AbstractLayer implements BulkRetrievable
     }
 
     /**
-     * Get the estimated size in bytes of the placenames not in the World Wind file cache for the given sector and
+     * Get the estimated size in bytes of the placenames not in the WorldWind file cache for the given sector and
      * resolution.
      * <p/>
      * Note that the target resolution must be provided in radians of latitude per texel, which is the resolution in
@@ -1314,7 +1314,7 @@ public class PlaceNameLayer extends AbstractLayer implements BulkRetrievable
      *
      * @param sector     the sector to estimate.
      * @param resolution the target resolution, provided in radians of latitude per texel.
-     * @param fileStore  the file store to examine. If null the current World Wind file cache is used.
+     * @param fileStore  the file store to examine. If null the current WorldWind file cache is used.
      *
      * @return the estimated size in byte of the missing placenames.
      *

--- a/src/gov/nasa/worldwind/layers/placename/PlaceNameLayerBulkDownloader.java
+++ b/src/gov/nasa/worldwind/layers/placename/PlaceNameLayerBulkDownloader.java
@@ -18,7 +18,7 @@ import java.nio.ByteBuffer;
 import java.util.*;
 
 /**
- * Downloads placenames not currently available in the World Wind file cache or a specified {@link FileStore}. The class
+ * Downloads placenames not currently available in the WorldWind file cache or a specified {@link FileStore}. The class
  * derives from {@link Thread} and is meant to operate in its own thread.
  * <p/>
  * The sector and resolution associated with the downloader are specified during construction and are final.
@@ -36,7 +36,7 @@ public class PlaceNameLayerBulkDownloader extends BulkRetrievalThread
     protected long pollDelay = RETRIEVAL_SERVICE_POLL_DELAY;
 
     /**
-     * Constructs a downloader to retrieve placenames not currently available in the World Wind file cache.
+     * Constructs a downloader to retrieve placenames not currently available in the WorldWind file cache.
      * <p/>
      * The thread returned is not started during construction, the caller must start the thread.
      *

--- a/src/gov/nasa/worldwind/layers/rpf/RPFTiledImageLayer.java
+++ b/src/gov/nasa/worldwind/layers/rpf/RPFTiledImageLayer.java
@@ -52,7 +52,7 @@ public class RPFTiledImageLayer extends TiledImageLayer
         Angle latOrigin = levels.getTileOrigin().getLatitude();
         Angle lonOrigin = levels.getTileOrigin().getLongitude();
 
-        // Determine the row and column offset from the common World Wind global tiling origin.
+        // Determine the row and column offset from the common WorldWind global tiling origin.
         int firstRow = Tile.computeRow(dLat, sector.getMinLatitude(), latOrigin);
         int firstCol = Tile.computeColumn(dLon, sector.getMinLongitude(), lonOrigin);
         int lastRow = Tile.computeRow(dLat, sector.getMaxLatitude(), latOrigin);

--- a/src/gov/nasa/worldwind/ogc/collada/ColladaParserContext.java
+++ b/src/gov/nasa/worldwind/ogc/collada/ColladaParserContext.java
@@ -165,7 +165,7 @@ public class ColladaParserContext extends BasicXMLEventParserContext
         this.parsers.put(new QName(ns, "lines"), new ColladaLines(ns));
         this.parsers.put(new QName(ns, "extra"), new ColladaExtra(ns));
 
-        // The following elements are valid COLLADA markup, but are not used by World Wind.
+        // The following elements are valid COLLADA markup, but are not used by WorldWind.
         parser = new ColladaUnsupported(ns);
         this.parsers.put(new QName(ns, "library_cameras"), parser);
         this.parsers.put(new QName(ns, "instance_camera"), parser);

--- a/src/gov/nasa/worldwind/ogc/collada/ColladaUnsupported.java
+++ b/src/gov/nasa/worldwind/ogc/collada/ColladaUnsupported.java
@@ -7,7 +7,7 @@
 package gov.nasa.worldwind.ogc.collada;
 
 /**
- * Parser class for COLLADA elements that are not used by World Wind.
+ * Parser class for COLLADA elements that are not used by WorldWind.
  *
  * @author pabercrombie
  * @version $Id: ColladaUnsupported.java 642 2012-06-14 17:31:29Z pabercrombie $

--- a/src/gov/nasa/worldwind/ogc/collada/impl/ColladaController.java
+++ b/src/gov/nasa/worldwind/ogc/collada/impl/ColladaController.java
@@ -11,8 +11,8 @@ import gov.nasa.worldwind.render.*;
 import gov.nasa.worldwind.util.Logging;
 
 /**
- * Executes the mapping from COLLADA to World Wind. Traverses a parsed COLLADA document and creates the appropriate
- * World Wind object to represent the COLLADA model.
+ * Executes the mapping from COLLADA to WorldWind. Traverses a parsed COLLADA document and creates the appropriate
+ * WorldWind object to represent the COLLADA model.
  *
  * @author pabercrombie
  * @version $Id: ColladaController.java 661 2012-06-26 18:02:23Z pabercrombie $

--- a/src/gov/nasa/worldwind/ogc/collada/impl/package.html
+++ b/src/gov/nasa/worldwind/ogc/collada/impl/package.html
@@ -12,6 +12,6 @@
 </head>
 <body>
 <p>Provides classes for rendering COLLADA documents. The {@link gov.nasa.worldwind.ogc.collada.impl.ColladaController}
-   can be used to render a parsed COLLADA document in World Wind.</p>
+   can be used to render a parsed COLLADA document in WorldWind.</p>
 </body>
 </html>

--- a/src/gov/nasa/worldwind/ogc/kml/KMLLink.java
+++ b/src/gov/nasa/worldwind/ogc/kml/KMLLink.java
@@ -286,8 +286,8 @@ public class KMLLink extends KMLAbstractObject
      * [cameraAlt]</code> - view's eye position.</li> <li><code>[horizFov], [vertFov]</code> - view's horizontal and
      * vertical field of view.</li> <li><code>[horizPixels], [vertPixels]</code> - width and height of the
      * viewport.</li> <li><code>[terrainEnabled]</code> - always <code>true</code></li> <li><code>[clientVersion]</code>
-     * - World Wind client version.</li> <li><code>[clientName]</code> - World Wind client name.</li>
-     * <li><code>[kmlVersion]</code> - KML version supported by World Wind.</li> <li><code>[language]</code> - current
+     * - WorldWind client version.</li> <li><code>[clientName]</code> - WorldWind client name.</li>
+     * <li><code>[kmlVersion]</code> - KML version supported by WorldWind.</li> <li><code>[language]</code> - current
      * locale's language.</li> </ul> If the <code>viewFormat</code> is unspecified, and the <code>viewRefreshMode</code>
      * is one of <code>onRequest</code>, <code>onStop</code> or <code>onRegion</code>, this automatically appends the
      * following information to the query string: <code>BBOX=[bboxWest],[bboxSouth],[bboxEast],[bboxNorth]</code>. The

--- a/src/gov/nasa/worldwind/ogc/kml/KMLNetworkLink.java
+++ b/src/gov/nasa/worldwind/ogc/kml/KMLNetworkLink.java
@@ -443,7 +443,7 @@ public class KMLNetworkLink extends KMLAbstractContainer implements PropertyChan
 
     /**
      * Indicates whether the network resource references by this <code>KMLNetworkLink</code> should be retrieved to the
-     * World Wind cache or to a temporary location. This returns <code>true</code> if all of the following conditions
+     * WorldWind cache or to a temporary location. This returns <code>true</code> if all of the following conditions
      * are met, and <code>false</code> otherwise:
      * <p/>
      * <ul> <li>This network link has either a <code>Link</code> or a <code>Url</code> element.</li> <li>The Link or Url

--- a/src/gov/nasa/worldwind/ogc/kml/KMLRoot.java
+++ b/src/gov/nasa/worldwind/ogc/kml/KMLRoot.java
@@ -577,7 +577,7 @@ public class KMLRoot extends KMLAbstractObject implements KMLRenderable
         if (absentResourceList.isResourceAbsent(link))
             return null;
 
-        // Store remote files in the World Wind cache by default. This provides backward compatibility with applications
+        // Store remote files in the WorldWind cache by default. This provides backward compatibility with applications
         // depending on resolveReference's behavior prior to the addition of the cacheRemoteFile parameter.
         Object o = this.resolveReference(link, true);
 
@@ -609,7 +609,7 @@ public class KMLRoot extends KMLAbstractObject implements KMLRenderable
      * method may not return the same temporary location.
      *
      * @param link            the document address in the form address#identifier.
-     * @param cacheRemoteFile <code>true</code> to store remote documents in the World Wind cache, or <code>false</code>
+     * @param cacheRemoteFile <code>true</code> to store remote documents in the WorldWind cache, or <code>false</code>
      *                        to store remote documents in a temporary location. Has no effect if the address is a local
      *                        document.
      *
@@ -762,7 +762,7 @@ public class KMLRoot extends KMLAbstractObject implements KMLRenderable
             throw new IllegalArgumentException(message);
         }
 
-        // Store remote files in the World Wind cache by default. This provides backward compatibility with applications
+        // Store remote files in the WorldWind cache by default. This provides backward compatibility with applications
         // depending on resolveRemoteReference's behavior prior to the addition of the cacheRemoteFile parameter.
         return this.resolveRemoteReference(linkBase, linkRef, true);
     }
@@ -778,14 +778,14 @@ public class KMLRoot extends KMLAbstractObject implements KMLRenderable
      * for the KML file identified by {@code linkBase}. Otherwise the return value is a {@link URL} to the file in the
      * file cache or a temporary location, depending on the value of <code>cacheRemoteFile</code>.
      * <p/>
-     * The <code>cacheRemoteFile</code> parameter specifies whether to store a retrieved remote file in the World Wind
+     * The <code>cacheRemoteFile</code> parameter specifies whether to store a retrieved remote file in the WorldWind
      * cache or in a temporary location. This parameter has no effect if the file exists locally. The temporary location
      * for a retrieved file does not persist between runtime sessions, and subsequent invocations of this method may not
      * return the same temporary location.
      *
      * @param linkBase        the address of the document containing the requested element.
      * @param linkRef         the element's identifier.
-     * @param cacheRemoteFile <code>true</code> to store remote files in the World Wind cache, or <code>false</code> to
+     * @param cacheRemoteFile <code>true</code> to store remote files in the WorldWind cache, or <code>false</code> to
      *                        store remote files in a temporary location. Has no effect if the address is a local file.
      *
      * @return URL to the requested file, parsed KMLRoot, or KML feature. Returns null if the document is not yet
@@ -867,13 +867,13 @@ public class KMLRoot extends KMLAbstractObject implements KMLRenderable
      * The return value is a parsed KMLRoot representing the linked document. The return value is null if the linked
      * file is not a KML file, or is not yet available in the FileStore.
      * <p/>
-     * The <code>cacheRemoteFile</code> parameter specifies whether to store a retrieved remote file in the World Wind
+     * The <code>cacheRemoteFile</code> parameter specifies whether to store a retrieved remote file in the WorldWind
      * cache or in a temporary location. This parameter has no effect if the file exists locally. The temporary location
      * for a retrieved file does not persist between runtime sessions, and subsequent invocations of this method may not
      * return the same temporary location.
      *
      * @param link            the address to resolve
-     * @param cacheRemoteFile <code>true</code> to store remote files in the World Wind cache, or <code>false</code> to
+     * @param cacheRemoteFile <code>true</code> to store remote files in the WorldWind cache, or <code>false</code> to
      *                        store remote files in a temporary location. Has no effect if the address is a local file.
      * @param updateTime      the time at which the link was last updated. If a cached file exists for the specified
      *                        resource, the file must have been retrieved after the link update time. Otherwise, the

--- a/src/gov/nasa/worldwind/ogc/kml/impl/KMLController.java
+++ b/src/gov/nasa/worldwind/ogc/kml/impl/KMLController.java
@@ -12,7 +12,7 @@ import gov.nasa.worldwind.ogc.kml.KMLRoot;
 import gov.nasa.worldwind.render.*;
 
 /**
- * Executes the mapping from KML to World Wind. Traverses a parsed KML document and creates the appropriate World Wind
+ * Executes the mapping from KML to WorldWind. Traverses a parsed KML document and creates the appropriate WorldWind
  * object to represent the KML.
  *
  * @author tag

--- a/src/gov/nasa/worldwind/ogc/kml/impl/KMLSurfacePolygonImpl.java
+++ b/src/gov/nasa/worldwind/ogc/kml/impl/KMLSurfacePolygonImpl.java
@@ -61,7 +61,7 @@ public class KMLSurfacePolygonImpl extends SurfacePolygon implements KMLRenderab
 
         KMLPolygon polygon = (KMLPolygon) geom;
 
-        // KMLPolygon's use linear interpolation between corners by definition. Configure the World Wind SurfacePolygon
+        // KMLPolygon's use linear interpolation between corners by definition. Configure the WorldWind SurfacePolygon
         // to use the appropriate path type for linear interpolation in geographic coordinates.
         this.setPathType(AVKey.LINEAR);
 

--- a/src/gov/nasa/worldwind/ogc/kml/impl/KMLUtil.java
+++ b/src/gov/nasa/worldwind/ogc/kml/impl/KMLUtil.java
@@ -113,7 +113,7 @@ public class KMLUtil
      * Translate a WorldWind units constant ({@link AVKey#PIXELS}, {@link AVKey#INSET_PIXELS}, or {@link AVKey#FRACTION}
      * to the corresponding KML unit string ("pixels", "insetPixels", or "fraction").
      *
-     * @param units World Wind units to translate.
+     * @param units WorldWind units to translate.
      *
      * @return KML units, or null if the argument is not a valid WW unit.
      */

--- a/src/gov/nasa/worldwind/ogc/kml/package.html
+++ b/src/gov/nasa/worldwind/ogc/kml/package.html
@@ -39,8 +39,8 @@
         defined by Google. Use these classes to obtain the contents of individual elements of the KML file.
     </li>
 </ol>
-The classes in this package only read and parse a KML file. Mapping them to shapes, annotations and other World Wind
-objects is a separate step. World Wind provides default mappings for many KML elements, but an application is fully able
+The classes in this package only read and parse a KML file. Mapping them to shapes, annotations and other WorldWind
+objects is a separate step. WorldWind provides default mappings for many KML elements, but an application is fully able
 to provide its own, and in some cases is expected to.
 <h4>Extending the Classes</h4>
 

--- a/src/gov/nasa/worldwind/render/AbstractAnnotationBalloon.java
+++ b/src/gov/nasa/worldwind/render/AbstractAnnotationBalloon.java
@@ -188,7 +188,7 @@ public abstract class AbstractAnnotationBalloon extends AbstractBalloon
             // Apply the computed balloon size and offset to the internal annotation's attributes. Adjust the screen
             // offset so that an offset of (0, 0) pixels maps to the annotation's lower left corner, and an offset of
             // (1, 1) fractions maps to the annotation's upper right corner. We do this to present a consistent meaning
-            // for offset throughout the World Wind SDK. By default, annotation's offset is relative to it's bottom
+            // for offset throughout the WorldWind SDK. By default, annotation's offset is relative to it's bottom
             // center. We apply an additional offset of width/2 to compensate for this.
             annotationAttrs.setSize(screenSize);
             annotationAttrs.setDrawOffset(

--- a/src/gov/nasa/worldwind/render/AbstractBrowserBalloon.java
+++ b/src/gov/nasa/worldwind/render/AbstractBrowserBalloon.java
@@ -1648,7 +1648,7 @@ public abstract class AbstractBrowserBalloon extends AbstractBalloon implements 
             if (linkParams.getValue(AVKey.BOUNDS) == null || linkParams.getValue(AVKey.RECTANGLES) == null)
                 continue;
 
-            // Translate the bounds from WebView coordinates to World Window screen coordinates.
+            // Translate the bounds from WebView coordinates to WorldWindow screen coordinates.
             Rectangle bounds = new Rectangle((Rectangle) linkParams.getValue(AVKey.BOUNDS));
             bounds.translate(obb.webViewRect.x, obb.webViewRect.y);
 

--- a/src/gov/nasa/worldwind/render/BalloonAttributes.java
+++ b/src/gov/nasa/worldwind/render/BalloonAttributes.java
@@ -9,7 +9,7 @@ package gov.nasa.worldwind.render;
 import java.awt.*;
 
 /**
- * Holds attributes for World Wind {@link gov.nasa.worldwind.render.Balloon} shapes. Changes made to the attributes are
+ * Holds attributes for WorldWind {@link gov.nasa.worldwind.render.Balloon} shapes. Changes made to the attributes are
  * applied to the balloon when the <code>WorldWindow</code> renders the next frame. Instances of
  * <code>BalloonAttributes</code> may be shared by many balloons, thereby reducing the memory normally required to store
  * attributes for each balloon.

--- a/src/gov/nasa/worldwind/render/BasicBalloonAttributes.java
+++ b/src/gov/nasa/worldwind/render/BasicBalloonAttributes.java
@@ -14,7 +14,7 @@ import java.util.*;
 
 /**
  * Basic implementation of the {@link gov.nasa.worldwind.render.BalloonAttributes} interface. Extends
- * <code>BasicShapeAttributes</code> to include attributes for World Wind {@link gov.nasa.worldwind.render.Balloon}
+ * <code>BasicShapeAttributes</code> to include attributes for WorldWind {@link gov.nasa.worldwind.render.Balloon}
  * shapes.
  *
  * @author pabercrombie

--- a/src/gov/nasa/worldwind/render/DrawContext.java
+++ b/src/gov/nasa/worldwind/render/DrawContext.java
@@ -52,7 +52,7 @@ public interface DrawContext extends WWObject, Disposable
 
     /**
      * Retrieves the current <code>javax.media.opengl.GL</code>. A <code>GL</code> or <code>GLU</code> is required for
-     * all graphical rendering in World Wind.
+     * all graphical rendering in WorldWind.
      *
      * @return the current <code>GL</code> if available, null otherwise
      *
@@ -62,7 +62,7 @@ public interface DrawContext extends WWObject, Disposable
 
     /**
      * Retrieves the current <code>javax.media.opengl.glu.GLU</code>. A <code>GLU</code> or <code>GL</code> is required
-     * for all graphical rendering in World Wind.
+     * for all graphical rendering in WorldWind.
      *
      * @return the current <code>GLU</code> if available, null otherwise
      *

--- a/src/gov/nasa/worldwind/render/ExtrudedPolygon.java
+++ b/src/gov/nasa/worldwind/render/ExtrudedPolygon.java
@@ -57,7 +57,7 @@ import java.util.*;
  * Boundaries are required to be closed, their first location must be equal to their last location. Boundaries that are
  * not closed are explicitly closed by this shape when they are specified.
  * <p/>
- * Extruded polygons are safe to share among World Windows. They should not be shared among layers in the same World
+ * Extruded polygons are safe to share among WorldWindows. They should not be shared among layers in the same World
  * Window.
  * <p/>
  * In order to support simultaneous use of this shape with multiple globes (windows), this shape maintains a cache of

--- a/src/gov/nasa/worldwind/render/Polygon.java
+++ b/src/gov/nasa/worldwind/render/Polygon.java
@@ -28,7 +28,7 @@ import java.util.*;
 /**
  * /** A 3D polygon. The polygon may be complex with multiple internal but not intersecting contours.
  * <p/>
- * Polygons are safe to share among World Windows. They should not be shared among layers in the same World Window.
+ * Polygons are safe to share among WorldWindows. They should not be shared among layers in the same WorldWindow.
  * <p/>
  * In order to support simultaneous use of this shape with multiple globes (windows), this shape maintains a cache of
  * data computed relative to each globe. During rendering, the data for the currently active globe, as indicated in the

--- a/src/gov/nasa/worldwind/render/ScreenImage.java
+++ b/src/gov/nasa/worldwind/render/ScreenImage.java
@@ -22,7 +22,7 @@ import java.io.*;
 import java.net.URL;
 
 /**
- * Draws an image parallel to the screen at a specified screen location relative to the World Window. If no image is
+ * Draws an image parallel to the screen at a specified screen location relative to the WorldWindow. If no image is
  * specified, a filled rectangle is drawn in its place.
  *
  * @author tag
@@ -119,7 +119,7 @@ public class ScreenImage extends WWObjectImpl implements Renderable, Exportable
 
     /**
      * Convenience method to specify the location of the image on the screen. The specified <code>screenLocation</code>
-     * is relative to the upper-left corner of the World Window, and the image is centered on this location.
+     * is relative to the upper-left corner of the WorldWindow, and the image is centered on this location.
      *
      * @param screenLocation the screen location on which to center the image. May be null, in which case the image is
      *                       not displayed.

--- a/src/gov/nasa/worldwind/render/ShapeAttributes.java
+++ b/src/gov/nasa/worldwind/render/ShapeAttributes.java
@@ -9,7 +9,7 @@ import gov.nasa.worldwind.Exportable;
 import gov.nasa.worldwind.util.RestorableSupport;
 
 /**
- * Holds common attributes for World Wind shapes such as {@link gov.nasa.worldwind.render.Path}, {@link
+ * Holds common attributes for WorldWind shapes such as {@link gov.nasa.worldwind.render.Path}, {@link
  * gov.nasa.worldwind.render.Polygon}, and {@link gov.nasa.worldwind.render.SurfaceShape}. Changes made to the
  * attributes are applied to the shape when the <code>WorldWindow</code> renders the next frame. Instances of
  * <code>ShapeAttributes</code> may be shared by many shapes, thereby reducing the memory normally required to store

--- a/src/gov/nasa/worldwind/render/SurfaceObjectTileBuilder.java
+++ b/src/gov/nasa/worldwind/render/SurfaceObjectTileBuilder.java
@@ -22,7 +22,7 @@ import java.util.List;
 /**
  * Builds a list of {@link gov.nasa.worldwind.render.SurfaceTile} instances who's content is defined by a specified set
  * of {@link gov.nasa.worldwind.render.SurfaceRenderable} instances. It's typically not necessary to use
- * SurfaceObjectTileBuilder directly. World Wind's default scene controller automatically batches instances of
+ * SurfaceObjectTileBuilder directly. WorldWind's default scene controller automatically batches instances of
  * SurfaceRenderable in a single SurfaceObjectTileBuilder. Applications that need to draw basic surface shapes should
  * use or extend {@link gov.nasa.worldwind.render.SurfaceShape} instead of using SurfaceObjectTileBuilder directly.
  * <p/>
@@ -30,7 +30,7 @@ import java.util.List;
  * renderables. This assembles a set of surface tiles that meet the resolution requirements for the specified draw
  * context, then draws the surface renderables into those offscreen surface tiles by calling render on each instance.
  * This process may temporarily use the framebuffer to perform offscreen rendering, and therefore should be called
- * during the preRender method of a World Wind layer. See the {@link gov.nasa.worldwind.render.PreRenderable} interface
+ * during the preRender method of a WorldWind layer. See the {@link gov.nasa.worldwind.render.PreRenderable} interface
  * for details. Once built, the surface tiles can be rendered by a {@link gov.nasa.worldwind.render.SurfaceTileRenderer}.
  * <p/>
  * By default, SurfaceObjectTileBuilder creates texture tiles with a width and height of 512 pixels, and with internal
@@ -371,7 +371,7 @@ public class SurfaceObjectTileBuilder
      * Assembles the surface tiles and draws any surface renderables in the iterable into those offscreen tiles. The
      * surface tiles are assembled to meet the necessary resolution of to the draw context's {@link
      * gov.nasa.worldwind.View}. This may temporarily use the framebuffer to perform offscreen rendering, and therefore
-     * should be called during the preRender method of a World Wind {@link gov.nasa.worldwind.layers.Layer}.
+     * should be called during the preRender method of a WorldWind {@link gov.nasa.worldwind.layers.Layer}.
      * <p/>
      * This does nothing if the specified iterable is null, is empty or contains no surface renderables.
      *

--- a/src/gov/nasa/worldwind/render/WWIcon.java
+++ b/src/gov/nasa/worldwind/render/WWIcon.java
@@ -12,7 +12,7 @@ import gov.nasa.worldwind.geom.*;
 import java.awt.*;
 
 /**
- * Provides a general interface for icons rendered by World Wind. Icons have a source image and optionally a background
+ * Provides a general interface for icons rendered by WorldWind. Icons have a source image and optionally a background
  * image. They may also have an associated tool tip. An icon has a geographic position. The indication of that position
  * is determined by implementations. The simplest implementation is to center the icon at the position, but association
  * by leader lines and other mechanisms are appropriate.

--- a/src/gov/nasa/worldwind/render/airspaces/AirspaceAttributes.java
+++ b/src/gov/nasa/worldwind/render/airspaces/AirspaceAttributes.java
@@ -9,10 +9,10 @@ package gov.nasa.worldwind.render.airspaces;
 import gov.nasa.worldwind.render.*;
 
 /**
- * Holds common attributes for World Wind {@link Airspace} shapes. AirspaceAttributes was originally designed as a
+ * Holds common attributes for WorldWind {@link Airspace} shapes. AirspaceAttributes was originally designed as a
  * special purpose attribute bundle for Airspace, but is now a redundant subinterface of {@link
  * gov.nasa.worldwind.render.ShapeAttributes}. AirspaceAttributes is still used by Airspace shapes to ensure backward
- * compatibility with earlier versions of World Wind. Usage of methods unique to AirspaceAttributes should be replaced
+ * compatibility with earlier versions of WorldWind. Usage of methods unique to AirspaceAttributes should be replaced
  * with the equivalent methods in ShapeAttributes.
  *
  * @author dcollins

--- a/src/gov/nasa/worldwind/render/airspaces/BasicAirspaceAttributes.java
+++ b/src/gov/nasa/worldwind/render/airspaces/BasicAirspaceAttributes.java
@@ -15,7 +15,7 @@ import javax.media.opengl.*;
  * Basic implementation of the {@link gov.nasa.worldwind.render.airspaces.AirspaceAttributes} interface.
  * AirspaceAttributes was originally designed as a special purpose attribute bundle for {@link Airspace} shapes, but is
  * now redundant subclass of {@link gov.nasa.worldwind.render.BasicShapeAttributes}. BasicAirspaceAttributes is still
- * supported to ensure backward compatibility with earlier versions of World Wind. Usage of methods unique to
+ * supported to ensure backward compatibility with earlier versions of WorldWind. Usage of methods unique to
  * AirspaceAttributes should be replaced with the equivalent methods in ShapeAttributes.
  *
  * @author tag

--- a/src/gov/nasa/worldwind/retrieve/BulkRetrievable.java
+++ b/src/gov/nasa/worldwind/retrieve/BulkRetrievable.java
@@ -11,7 +11,7 @@ import gov.nasa.worldwind.geom.Sector;
 
 /**
  * Interface for classes whose data may be retrieved in bulk from its remote source. When used, will copy the requested
- * data to either the local World Wind cache or a specified filestore. Data already contained in the specified location
+ * data to either the local WorldWind cache or a specified filestore. Data already contained in the specified location
  * is not recopied.
  *
  * @author Patrick Murris
@@ -20,7 +20,7 @@ import gov.nasa.worldwind.geom.Sector;
 public interface BulkRetrievable
 {
     /**
-     * Initiates data retrieval to the current World Wind data cache. The method starts a new thread to perform the
+     * Initiates data retrieval to the current WorldWind data cache. The method starts a new thread to perform the
      * retrieval. The thread terminates when either all the requested data has been retrieved or when any data not
      * retrieved is determined to be unretrievable.
      *
@@ -37,7 +37,7 @@ public interface BulkRetrievable
     BulkRetrievalThread makeLocal(Sector sector, double resolution, BulkRetrievalListener listener);
 
     /**
-     * Estimates the amount of data, in bytes, that must be retrieved to the World Wind data cache for a specified
+     * Estimates the amount of data, in bytes, that must be retrieved to the WorldWind data cache for a specified
      * sector and resolution.
      *
      * @param sector     the sector for which to retrieve the data.
@@ -55,7 +55,7 @@ public interface BulkRetrievable
      * @param sector     the sector for which to retrieve the data.
      * @param resolution the resolution desired. All data within the specified sector up to and including this
      *                   resolution is downloaded.
-     * @param fileStore  the location to place the data. If null, the current World Wind cache is used.
+     * @param fileStore  the location to place the data. If null, the current WorldWind cache is used.
      *
      * @return the estimated data size, in bytes.
      */
@@ -73,7 +73,7 @@ public interface BulkRetrievable
      *                   individual retrievals. Note: The listener is called on the thread performing the download,
      *                   which is not the event dispatch thread. Therefore any interaction with AWT or Swing within the
      *                   call must be done within a call to SwingUtilities.invokeLater().
-     * @param fileStore  the location to place the data. If null, the current World Wind cache is used.
+     * @param fileStore  the location to place the data. If null, the current WorldWind cache is used.
      *
      * @return returns the running thread created to perform the retrieval.
      */

--- a/src/gov/nasa/worldwind/retrieve/URLRetriever.java
+++ b/src/gov/nasa/worldwind/retrieve/URLRetriever.java
@@ -27,7 +27,7 @@ import java.util.zip.*;
 public abstract class URLRetriever extends WWObjectImpl implements Retriever
 {
     /**
-     * Applications never need to use this constant. It provides compatibility with very old World Wind tile servers
+     * Applications never need to use this constant. It provides compatibility with very old WorldWind tile servers
      * that deliver zipped content without identifying the content type as other than application/zip. In these cases,
      * the object requesting the content must know the content type to expect, and also requires that the zip file be
      * opened and only its first entry returned.

--- a/src/gov/nasa/worldwind/symbology/SymbologyConstants.java
+++ b/src/gov/nasa/worldwind/symbology/SymbologyConstants.java
@@ -9,7 +9,7 @@ package gov.nasa.worldwind.symbology;
 import java.util.*;
 
 /**
- * Defines constants used by the World Wind symbology classes, including symbolic constants and modifier keys for
+ * Defines constants used by the WorldWind symbology classes, including symbolic constants and modifier keys for
  * MIL-STD-2525 tactical symbols and tactical graphics.
  *
  * @author dcollins

--- a/src/gov/nasa/worldwind/symbology/TacticalGraphic.java
+++ b/src/gov/nasa/worldwind/symbology/TacticalGraphic.java
@@ -59,9 +59,9 @@ import gov.nasa.worldwind.util.UnitsFormat;
  * RenderableLayer graphicLayer = new RenderableLayer();
  * graphicLayer.addRenderable(graphic);
  *
- * // Add the layer to the world window's model and request that the layer redraw itself. The world window draws the
+ * // Add the layer to the WorldWindow's model and request that the layer redraw itself. The WorldWindow draws the
  * // graphic on the globe at the specified position. Interactions between the graphic and the cursor are returned in
- * // the world window's picked object list, and reported to the world window's select listeners.
+ * // the WorldWindow's picked object list, and reported to the WorldWindow's select listeners.
  * WorldWindow wwd = ... // A reference to your application's WorldWind instance.
  * wwd.getModel().getLayers().add(graphicLayer);
  * wwd.redraw();

--- a/src/gov/nasa/worldwind/symbology/TacticalSymbol.java
+++ b/src/gov/nasa/worldwind/symbology/TacticalSymbol.java
@@ -48,9 +48,9 @@ import gov.nasa.worldwind.util.UnitsFormat;
  * RenderableLayer symbolLayer = new RenderableLayer();
  * symbolLayer.addRenderable(symbol);
  *
- * // Add the layer to the world window's model and request that the window redraw itself. The world window draws the
+ * // Add the layer to the WorldWindow's model and request that the window redraw itself. The WorldWindow draws the
  * // symbol on the globe at the specified position. Interactions between the symbol and the cursor are returned in the
- * // world window's picked object list, and reported to the world window's select listeners.
+ * // WorldWindow's picked object list, and reported to the WorldWindow's select listeners.
  * WorldWindow wwd = ... // A reference to your application's WorldWindow instance.
  * wwd.getModel().getLayers().add(symbolLayer);
  * wwd.redraw();

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/DefaultOffsets.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/DefaultOffsets.java
@@ -15,7 +15,7 @@ import static gov.nasa.worldwind.symbology.milstd2525.graphics.TacGrpSidc.*;
 /**
  * Object to provide default offsets for MIL-STD-2525C tactical point graphics. The offset is used to align a point on
  * the graphic with the graphic's geographic position. This class automatically populates the map with values
- * appropriate for the point graphic images supplied by World Wind.
+ * appropriate for the point graphic images supplied by WorldWind.
  *
  * @author pabercrombie
  * @version $Id: DefaultOffsets.java 542 2012-04-24 19:08:12Z pabercrombie $

--- a/src/gov/nasa/worldwind/terrain/BasicElevationModel.java
+++ b/src/gov/nasa/worldwind/terrain/BasicElevationModel.java
@@ -687,7 +687,7 @@ public class BasicElevationModel extends AbstractElevationModel implements BulkR
 
     /**
      * Start a new {@link BulkRetrievalThread} that downloads all elevations for a given sector and resolution to the
-     * current World Wind file cache, without downloading imagery already in the cache.
+     * current WorldWind file cache, without downloading imagery already in the cache.
      * <p/>
      * This method creates and starts a thread to perform the download. A reference to the thread is returned. To create
      * a downloader that has not been started, construct a {@link BasicElevationModelBulkDownloader}.
@@ -722,7 +722,7 @@ public class BasicElevationModel extends AbstractElevationModel implements BulkR
      *
      * @param sector     the sector to download data for.
      * @param resolution the target resolution, provided in radians of latitude per texel.
-     * @param fileStore  the file store in which to place the downloaded elevations. If null the current World Wind file
+     * @param fileStore  the file store in which to place the downloaded elevations. If null the current WorldWind file
      *                   cache is used.
      * @param listener   an optional retrieval listener. May be null.
      *
@@ -749,7 +749,7 @@ public class BasicElevationModel extends AbstractElevationModel implements BulkR
     }
 
     /**
-     * Get the estimated size in bytes of the elevations not in the World Wind file cache for the given sector and
+     * Get the estimated size in bytes of the elevations not in the WorldWind file cache for the given sector and
      * resolution.
      * <p/>
      * Note that the target resolution must be provided in radians of latitude per texel, which is the resolution in
@@ -776,7 +776,7 @@ public class BasicElevationModel extends AbstractElevationModel implements BulkR
      *
      * @param sector     the sector to estimate.
      * @param resolution the target resolution, provided in radians of latitude per texel.
-     * @param fileStore  the file store to examine. If null the current World Wind file cache is used.
+     * @param fileStore  the file store to examine. If null the current WorldWind file cache is used.
      *
      * @return the estimated size in bytes of the missing elevations.
      *
@@ -1620,7 +1620,7 @@ public class BasicElevationModel extends AbstractElevationModel implements BulkR
     protected synchronized MemoryCache getExtremesLookupCache()
     {
         // Note that the extremes lookup cache does not belong to the WorldWind memory cache set, therefore it will not
-        // be automatically cleared and disposed when World Wind is shutdown. However, since the extremes lookup cache
+        // be automatically cleared and disposed when WorldWind is shutdown. However, since the extremes lookup cache
         // is a local reference to this elevation model, it will be reclaimed by the JVM garbage collector when this
         // elevation model is reclaimed by the GC.
 
@@ -2021,7 +2021,7 @@ public class BasicElevationModel extends AbstractElevationModel implements BulkR
         //
         // Note that we use the URL's String representation as the cache key. We cannot use the URL itself, because
         // the cache invokes the methods Object.hashCode() and Object.equals() on the cache key. URL's implementations
-        // of hashCode() and equals() perform blocking IO calls. World Wind does not perform blocking calls during
+        // of hashCode() and equals() perform blocking IO calls. WorldWind does not perform blocking calls during
         // rendering, and this method is likely to be called from the rendering thread.
         WMSCapabilities caps;
         if (this.isNetworkRetrievalEnabled())

--- a/src/gov/nasa/worldwind/terrain/BasicElevationModelBulkDownloader.java
+++ b/src/gov/nasa/worldwind/terrain/BasicElevationModelBulkDownloader.java
@@ -20,7 +20,7 @@ import java.nio.ByteBuffer;
 import java.util.*;
 
 /**
- * Downloads elevation data not currently available in the World Wind file cache or a specified {@link FileStore}. The
+ * Downloads elevation data not currently available in the WorldWind file cache or a specified {@link FileStore}. The
  * class derives from {@link Thread} and is meant to operate in its own thread.
  * <p/>
  * The sector and resolution associated with the downloader are specified during construction and are final.
@@ -39,7 +39,7 @@ public class BasicElevationModelBulkDownloader extends BulkRetrievalThread
     protected ArrayList<Tile> missingTiles;
 
     /**
-     * Constructs a downloader to retrieve elevations not currently available in the World Wind file cache.
+     * Constructs a downloader to retrieve elevations not currently available in the WorldWind file cache.
      * <p/>
      * The thread returned is not started during construction, the caller must start the thread.
      *

--- a/src/gov/nasa/worldwind/terrain/BasicElevationModelFactory.java
+++ b/src/gov/nasa/worldwind/terrain/BasicElevationModelFactory.java
@@ -40,7 +40,7 @@ public class BasicElevationModelFactory extends BasicFactory
      * For non-compound models, this method maps the <code>serviceName</code> attribute of the
      * <code>ElevationModel/Service</code> element of the XML configuration document to the appropriate elevation-model
      * type. Service types recognized are:" <ul> <li>"WMS" for elevation models that draw their data from a WMS web
-     * service.</li> <li>"WWTileService" for elevation models that draw their data from a World Wind tile service.</li>
+     * service.</li> <li>"WWTileService" for elevation models that draw their data from a WorldWind tile service.</li>
      * <li>"Offline" for elevation models that draw their data only from the local cache.</li> </ul>
      *
      * @param configSource the configuration source. See above for supported types.

--- a/src/gov/nasa/worldwind/terrain/WCSElevationModel.java
+++ b/src/gov/nasa/worldwind/terrain/WCSElevationModel.java
@@ -37,7 +37,7 @@ public class WCSElevationModel extends BasicElevationModel
     /**
      * Create a new elevation model from a serialized restorable state string.
      *
-     * @param restorableStateInXml XML string in World Wind restorable state format.
+     * @param restorableStateInXml XML string in WorldWind restorable state format.
      *
      * @see #getRestorableState()
      */

--- a/src/gov/nasa/worldwind/util/AbstractHotSpot.java
+++ b/src/gov/nasa/worldwind/util/AbstractHotSpot.java
@@ -42,7 +42,7 @@ public abstract class AbstractHotSpot extends AVListImpl implements HotSpot
     }
 
     /**
-     * Called when the HotSpot is selected in the World Window. The default implementation does nothing. Override this
+     * Called when the HotSpot is selected in the WorldWindow. The default implementation does nothing. Override this
      * method to handle select events.
      *
      * @param event The event to handle.
@@ -82,7 +82,7 @@ public abstract class AbstractHotSpot extends AVListImpl implements HotSpot
     }
 
     /**
-     * Called when the mouse is clicked on the HotSpot in the World Window. The default implementation does nothing.
+     * Called when the mouse is clicked on the HotSpot in the WorldWindow. The default implementation does nothing.
      * Override this method to handle mouse click events.
      *
      * @param event The event to handle.
@@ -92,7 +92,7 @@ public abstract class AbstractHotSpot extends AVListImpl implements HotSpot
     }
 
     /**
-     * Called when the mouse is pressed over the HotSpot in the World Window. The default implementation does nothing.
+     * Called when the mouse is pressed over the HotSpot in the WorldWindow. The default implementation does nothing.
      * Override this method to handle mouse pressed events.
      *
      * @param event The event to handle.
@@ -102,7 +102,7 @@ public abstract class AbstractHotSpot extends AVListImpl implements HotSpot
     }
 
     /**
-     * Called when the mouse is released over the HotSpot in the World Window. The default implementation does nothing.
+     * Called when the mouse is released over the HotSpot in the WorldWindow. The default implementation does nothing.
      * Override this method to handle mouse released events.
      *
      * @param event The event to handle.
@@ -112,7 +112,7 @@ public abstract class AbstractHotSpot extends AVListImpl implements HotSpot
     }
 
     /**
-     * Called when the mouse enters the World Window and the HotSpot is active. The default implementation does nothing.
+     * Called when the mouse enters the WorldWindow and the HotSpot is active. The default implementation does nothing.
      * Override this method to handle mouse enter events.
      *
      * @param event The event to handle.
@@ -122,7 +122,7 @@ public abstract class AbstractHotSpot extends AVListImpl implements HotSpot
     }
 
     /**
-     * Called when the mouse exits the World Window and the HotSpot is active. The default implementation does nothing.
+     * Called when the mouse exits the WorldWindow and the HotSpot is active. The default implementation does nothing.
      * Override this method to handle mouse exit events.
      *
      * @param event The event to handle.
@@ -132,7 +132,7 @@ public abstract class AbstractHotSpot extends AVListImpl implements HotSpot
     }
 
     /**
-     * Called when the mouse is dragged in the World Window and the HotSpot is active. The default implementation does
+     * Called when the mouse is dragged in the WorldWindow and the HotSpot is active. The default implementation does
      * nothing. Override this method to handle mouse dragged events.
      *
      * @param event The event to handle.
@@ -142,7 +142,7 @@ public abstract class AbstractHotSpot extends AVListImpl implements HotSpot
     }
 
     /**
-     * Called when the cursor moves over the HotSpot in the World Window. The default implementation does nothing.
+     * Called when the cursor moves over the HotSpot in the WorldWindow. The default implementation does nothing.
      * Override this method to handle mouse move events.
      *
      * @param event The event to handle.
@@ -152,7 +152,7 @@ public abstract class AbstractHotSpot extends AVListImpl implements HotSpot
     }
 
     /**
-     * Called when the mouse wheel is moved in the World Window and HotSpot is active. The default implementation does
+     * Called when the mouse wheel is moved in the WorldWindow and HotSpot is active. The default implementation does
      * nothing. Override this method to handle mouse wheel events.
      *
      * @param event The event to handle.

--- a/src/gov/nasa/worldwind/util/BasicNetworkStatus.java
+++ b/src/gov/nasa/worldwind/util/BasicNetworkStatus.java
@@ -79,7 +79,7 @@ public class BasicNetworkStatus extends AVListImpl implements NetworkStatus
     /**
      * Determines and stores the network sites to test for public network connectivity. The sites are drawn from the
      * JVM's gov.nasa.worldwind.avkey.NetworkStatusTestSites property ({@link AVKey#NETWORK_STATUS_TEST_SITES}). If that
-     * property is not defined, the sites are drawn from the same property in the World Wind or application
+     * property is not defined, the sites are drawn from the same property in the WorldWind or application
      * configuration file. If the sites are not specified there, the set of sites specified in {@link
      * #DEFAULT_NETWORK_TEST_SITES} are used. To indicate an empty list in the JVM property or configuration file
      * property, specify an empty site list, "".

--- a/src/gov/nasa/worldwind/util/DataConfigurationFilter.java
+++ b/src/gov/nasa/worldwind/util/DataConfigurationFilter.java
@@ -11,7 +11,7 @@ import org.w3c.dom.*;
 /**
  * An implementation of {@link FileStoreFilter} which accepts XML configuration documents. Accepted document types are:
  * <ul> <li>Layer configuration documents</li> <li>ElevationModel configuration documents</li> <li>Installed data
- * configuration documents</li> <li>World Wind .NET LevelSet documents</li> </ul>
+ * configuration documents</li> <li>WorldWind .NET LevelSet documents</li> </ul>
  *
  * @author dcollins
  * @version $Id: DataConfigurationFilter.java 1171 2013-02-11 21:45:02Z dcollins $

--- a/src/gov/nasa/worldwind/util/DataConfigurationUtils.java
+++ b/src/gov/nasa/worldwind/util/DataConfigurationUtils.java
@@ -23,7 +23,7 @@ import java.net.*;
 import java.util.concurrent.*;
 
 /**
- * A collection of static methods useful for opening, reading, and otherwise working with World Wind data configuration
+ * A collection of static methods useful for opening, reading, and otherwise working with WorldWind data configuration
  * documents.
  *
  * @author dcollins
@@ -37,7 +37,7 @@ public class DataConfigurationUtils
     /**
      * Returns true if the specified {@link org.w3c.dom.Element} is a data configuration document. This recognizes the
      * following data configuration documents: <ul> <li>Layer Configuration Documents</li> <li>Elevation Model
-     * Configuration Documents</li> <li>Installed DataDescriptor Documents</li> <li>World Wind .NET LayerSet
+     * Configuration Documents</li> <li>Installed DataDescriptor Documents</li> <li>WorldWind .NET LayerSet
      * Documents</li> </ul>
      *
      * @param domElement the document in question.
@@ -83,7 +83,7 @@ public class DataConfigurationUtils
      * Returns the specified data configuration document transformed to a standard Layer or ElevationModel configuration
      * document. This returns the original document if the document is already in a standard form, or if the document is
      * not one of the recognized types. Installed DataDescriptor documents are transformed to standard Layer or
-     * ElevationModel configuration documents, depending on the document contents. World Wind .NET LayerSet documents
+     * ElevationModel configuration documents, depending on the document contents. WorldWind .NET LayerSet documents
      * are transformed to standard Layer configuration documents. This returns null if the document's root element is
      * null.
      *
@@ -128,7 +128,7 @@ public class DataConfigurationUtils
      * follows: <table> <tr><th>Document Type</th><th>Path to Display Name</th></tr> <tr><td>Layer
      * Configuration</td><td>./DisplayName</td></tr> <tr><td>Elevation Model Configuration</td><td>./DisplayName</td></tr>
      * <tr><td>Installed DataDescriptor</td><td>./property[@name="dataSet"]/property[@name="gov.nasa.worldwind.avkey.DatasetNameKey"]</td></tr>
-     * <tr><td>World Wind .NET LayerSet</td><td>./QuadTileSet/Name</td></tr> <tr><td>Other</td><td>null</td></tr>
+     * <tr><td>WorldWind .NET LayerSet</td><td>./QuadTileSet/Name</td></tr> <tr><td>Other</td><td>null</td></tr>
      * </table>
      *
      * @param domElement the data configuration document who's display name is returned.
@@ -172,7 +172,7 @@ public class DataConfigurationUtils
      * recognized types. This maps data configuration documents to a type string as follows: <table> <tr><th>Document
      * Type</th><th>Type String</th></tr> <tr><td>Layer Configuration</td><td>"Layer"</td></tr> <tr><td>Elevation Model
      * Configuration</td><td>"Elevation Model"</td></tr> <tr><td>Installed DataDescriptor</td><td>"Layer" or
-     * "ElevationModel"</td></tr> <tr><td>World Wind .NET LayerSet</td><td>"Layer"</td></tr>
+     * "ElevationModel"</td></tr> <tr><td>WorldWind .NET LayerSet</td><td>"Layer"</td></tr>
      * <tr><td>Other</td><td>null</td></tr> </table>
      *
      * @param domElement the data configuration document to determine a type for.
@@ -1810,7 +1810,7 @@ public class DataConfigurationUtils
 
         // Data descriptor files are written with the property "gov.nasa.worldwind.avkey.MissingDataValue". But it
         // means the value that denotes a missing data point, and not the value that replaces missing values.
-        // Translate that key here to MissingDataSignal, so it is properly understood by the World Wind API
+        // Translate that key here to MissingDataSignal, so it is properly understood by the WorldWind API
         // (esp. BasicElevationModel).
         Double d = WWXML.getDouble(context, "property[@name=\"gov.nasa.worldwind.avkey.MissingDataValue\"]", xpath);
         if (d != null)
@@ -1880,11 +1880,11 @@ public class DataConfigurationUtils
     }
 
     //**************************************************************//
-    //********************  World Wind .NET LayerSet Configuration  //
+    //********************  WorldWind .NET LayerSet Configuration  //
     //**************************************************************//
 
     /**
-     * Returns true if a specified document is a World Wind .NET LayerSet configuration document, and false otherwise.
+     * Returns true if a specified document is a WorldWind .NET LayerSet configuration document, and false otherwise.
      *
      * @param domElement the document in question.
      *
@@ -1908,7 +1908,7 @@ public class DataConfigurationUtils
     }
 
     /**
-     * Returns true if a specified XML event is the root of a World Wind .NET LayerSet configuration document, and false
+     * Returns true if a specified XML event is the root of a WorldWind .NET LayerSet configuration document, and false
      * otherwise.
      *
      * @param event the XML event in question.
@@ -1936,7 +1936,7 @@ public class DataConfigurationUtils
     }
 
     /**
-     * Parses World Wind .NET LayerSet configuration parameters from the specified document. This writes output as
+     * Parses WorldWind .NET LayerSet configuration parameters from the specified document. This writes output as
      * key-value pairs to params. If a parameter from the LayerSet document already exists in params, that parameter is
      * ignored. Supported key and parameter names are: <table> <tr><th>Parameter</th><th>Element
      * Path</th><th>Type</th></tr> <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#DISPLAY_NAME}</td><td>QuadTileSet/Name<td></td><td>String</td></tr>
@@ -2114,7 +2114,7 @@ public class DataConfigurationUtils
     }
 
     /**
-     * Transforms a World Wind .NET LayerSet configuration document to a standard layer configuration document.
+     * Transforms a WorldWind .NET LayerSet configuration document to a standard layer configuration document.
      *
      * @param domElement LayerSet document to transform.
      *

--- a/src/gov/nasa/worldwind/util/HotSpot.java
+++ b/src/gov/nasa/worldwind/util/HotSpot.java
@@ -34,7 +34,7 @@ public interface HotSpot extends SelectListener, KeyListener, MouseListener, Mou
     boolean isActive();
 
     /**
-     * Called when the HotSpot is selected in the World Window.
+     * Called when the HotSpot is selected in the WorldWindow.
      *
      * @param event The event to handle.
      */
@@ -62,56 +62,56 @@ public interface HotSpot extends SelectListener, KeyListener, MouseListener, Mou
     void keyReleased(KeyEvent event);
 
     /**
-     * Called when the mouse is clicked on the HotSpot in the World Window.
+     * Called when the mouse is clicked on the HotSpot in the WorldWindow.
      *
      * @param event The event to handle.
      */
     void mouseClicked(MouseEvent event);
 
     /**
-     * Called when the mouse is pressed over the HotSpot in the World Window.
+     * Called when the mouse is pressed over the HotSpot in the WorldWindow.
      *
      * @param event The event to handle.
      */
     void mousePressed(MouseEvent event);
 
     /**
-     * Called when the mouse is released over the HotSpot in the World Window.
+     * Called when the mouse is released over the HotSpot in the WorldWindow.
      *
      * @param event The event to handle.
      */
     void mouseReleased(MouseEvent event);
 
     /**
-     * Called when the mouse enters the World Window and the HotSpot is active.
+     * Called when the mouse enters the WorldWindow and the HotSpot is active.
      *
      * @param event The event to handle.
      */
     void mouseEntered(MouseEvent event);
 
     /**
-     * Called when the mouse exits the World Window and the HotSpot is active.
+     * Called when the mouse exits the WorldWindow and the HotSpot is active.
      *
      * @param event The event to handle.
      */
     void mouseExited(MouseEvent event);
 
     /**
-     * Called when the mouse is dragged in the World Window and the HotSpot is active.
+     * Called when the mouse is dragged in the WorldWindow and the HotSpot is active.
      *
      * @param event The event to handle.
      */
     void mouseDragged(MouseEvent event);
 
     /**
-     * Called when the cursor moves over the HotSpot in the World Window.
+     * Called when the cursor moves over the HotSpot in the WorldWindow.
      *
      * @param event The event to handle.
      */
     void mouseMoved(MouseEvent event);
 
     /**
-     * Called when the mouse wheel is moved in the World Window and HotSpot is active.
+     * Called when the mouse wheel is moved in the WorldWindow and HotSpot is active.
      *
      * @param event The event to handle.
      */

--- a/src/gov/nasa/worldwind/util/Logging.java
+++ b/src/gov/nasa/worldwind/util/Logging.java
@@ -14,7 +14,7 @@ import java.util.logging.Level;
 import java.util.logging.*;
 
 /**
- * This class of static methods provides the interface to logging for World Wind components. Logging is performed via
+ * This class of static methods provides the interface to logging for WorldWind components. Logging is performed via
  * {@link java.util.logging}. The default logger name is <code>gov.nasa.worldwind</code>. The logger name is
  * configurable via {@link gov.nasa.worldwind.Configuration}.
  *
@@ -33,7 +33,7 @@ public class Logging
     } // Prevent instantiation
 
     /**
-     * Returns the World Wind logger.
+     * Returns the WorldWind logger.
      *
      * @return The logger.
      */
@@ -54,7 +54,7 @@ public class Logging
 
     /**
      * Returns a specific logger. Does not access {@link gov.nasa.worldwind.Configuration} to determine the configured
-     * World Wind logger.
+     * WorldWind logger.
      * <p/>
      * This is needed by {@link gov.nasa.worldwind.Configuration} to avoid calls back into itself when its singleton
      * instance is not yet instantiated.
@@ -69,7 +69,7 @@ public class Logging
     }
 
     /**
-     * Retrieves a message from the World Wind message resource bundle.
+     * Retrieves a message from the WorldWind message resource bundle.
      *
      * @param property the property identifying which message to retrieve.
      *
@@ -90,7 +90,7 @@ public class Logging
     }
 
     /**
-     * Retrieves a message from the World Wind message resource bundle formatted with a single argument. The argument is
+     * Retrieves a message from the WorldWind message resource bundle formatted with a single argument. The argument is
      * inserted into the message via {@link java.text.MessageFormat}.
      *
      * @param property the property identifying which message to retrieve.
@@ -106,7 +106,7 @@ public class Logging
     }
 
     /**
-     * Retrieves a message from the World Wind message resource bundle formatted with specified arguments. The arguments
+     * Retrieves a message from the WorldWind message resource bundle formatted with specified arguments. The arguments
      * are inserted into the message via {@link java.text.MessageFormat}.
      *
      * @param property the property identifying which message to retrieve.

--- a/src/gov/nasa/worldwind/util/MessageStrings.properties
+++ b/src/gov/nasa/worldwind/util/MessageStrings.properties
@@ -775,13 +775,13 @@ BasicRetrievalService.CancellingTooOldRetrieval=Cancelling request too long on t
 BasicRetrievalService.ExceptionDuringRetrieval=Exception during retrieval of {0}
 BasicRetrievalService.ExecutionExceptionDuringRetrieval=Execution exception during retrieval of {0}
 BasicRetrievalService.ExceptionRetrievingContentSizes=Exception retrieving content sizes from Retriever {0}
-BasicRetrievalService.IdleThreadNamePrefix=Idle World Wind Retriever
+BasicRetrievalService.IdleThreadNamePrefix=Idle WorldWind Retriever
 BasicRetrievalService.ResourceRejectedQueueIsFull=Retrieval service rejected, queue is full, resource {0}
 BasicRetrievalService.ResourceRejected=Retrieval service rejected resource {0}
 BasicRetrievalService.RetrievalInterrupted=Retrieval of {0} was interrupted
 BasicRetrievalService.RetrievalCancelled=Retrieval of {0} was cancelled
 BasicRetrievalService.RetrieverPoolSizeIsLessThanOne=Retriever pool size is less than 1
-BasicRetrievalService.RunningThreadNamePrefix=Running World Wind Retriever:\u0020
+BasicRetrievalService.RunningThreadNamePrefix=Running WorldWind Retriever:\u0020
 BasicRetrievalService.UncaughtExceptionDuringRetrieval=Uncaught exception during retrieval on thread {0}
 
 BasicSceneController.GLContextNullStartRedisplay=GLContext is null at start of repaint
@@ -1221,8 +1221,8 @@ TextureAtlas.ExceptionAddingImage=Exception adding texture atlas image: {0}
 ThreadedTaskService.CancellingDuplicateTask=Cancelling duplicate task of {0}
 ThreadedTaskService.UncaughtExceptionDuringTask=Uncaught exception during task on thread {0}
 ThreadedTaskService.ResourceRejected=Task service rejected resource {0}
-ThreadedTaskService.RunningThreadNamePrefix=Running World Wind Task\u0020
-ThreadedTaskService.IdleThreadNamePrefix=Idle World Wind Task\u0020
+ThreadedTaskService.RunningThreadNamePrefix=Running WorldWind Task\u0020
+ThreadedTaskService.IdleThreadNamePrefix=Idle WorldWind Task\u0020
 
 TiledElevationModel.ExceptionCreatingElevationsUrl=Exception creating elevations URL for {0}
 TiledElevationModel.ExceptionSavingRetrievedElevationFile=Exception while saving retrieved elevation file to {0}
@@ -1357,8 +1357,8 @@ WorldFile.TooFewWorldFileValues=Number of world file values is less than the req
 WorldFile.UnrecognizedValues=The coordinate system of the latitude and longitude values in file {0} cannot be determined
 WorldFile.WorldFileNotFound=Cannot find world file for image {0}
 
-WorldWind.ExceptionCreatingComponent=Exception while creating World Wind component {0}
-WorldWind.ErrorCreatingComponent=Error while creating World Wind component {0}
+WorldWind.ExceptionCreatingComponent=Exception while creating WorldWind component {0}
+WorldWind.ErrorCreatingComponent=Error while creating WorldWind component {0}
 WorldWind.NoClassNameInConfigurationForKey=No class name in configuration for key {0}
 WorldWind.UnableToCreateClassForConfigurationKey=Unable to create class for configuration key {0}
 
@@ -1375,7 +1375,7 @@ WWDotNetLayerSetConverter.CannotInstallLayerSet=Cannot install WW.Net LayerSet {
 WWDotNetLayerSetConverter.CannotInstallToSelf=Cannot install WW.Net LayerSet {0} onto itself at {1}
 WWDotNetLayerSetConverter.CannotReadLayerSetConfigFile=Cannot read WW.Net LayerSet configuration {0}
 WWDotNetLayerSetConverter.CannotWriteLayerConfigFile=Cannot write layer configuration {0}
-WWDotNetLayerSetConverter.Description=World Wind .NET LayerSet (*.xml)
+WWDotNetLayerSetConverter.Description=WorldWind .NET LayerSet (*.xml)
 WWDotNetLayerSetConverter.ExceptionRemovingProductionState=Exception while removing production state for WW.Net LayerSet {0}
 WWDotNetLayerSetConverter.FileNotLayerSet=File is not a WW.Net LayerSet configuration {0}
 WWDotNetLayerSetConverter.FileWithoutParent=File has no parent folder {0}

--- a/src/gov/nasa/worldwind/util/NetworkStatus.java
+++ b/src/gov/nasa/worldwind/util/NetworkStatus.java
@@ -25,7 +25,7 @@ import java.util.List;
  * as not unreachable after a specifiable interval of time. If the host is once more logged as unavailable, its entry
  * returns to the unavailable state. This cycle continues indefinitely.
  * <p/>
- * Methods are provided to determine whether the public network can be reached and whether the NASA World Wind servers
+ * Methods are provided to determine whether the public network can be reached and whether the NASA WorldWind servers
  * cab be reached. The addresses used to detect public network access can be explicitly specified.
  *
  * @author tag
@@ -80,7 +80,7 @@ public interface NetworkStatus extends AVList
     boolean isNetworkUnavailable(long checkInterval);
 
     /**
-     * Indicates whether the NASA World Wind servers can be reached.
+     * Indicates whether the NASA WorldWind servers can be reached.
      *
      * @return false if the servers can be reached, otherwise true.
      */
@@ -102,17 +102,17 @@ public interface NetworkStatus extends AVList
     long getTryAgainInterval();
 
     /**
-     * Indicates whether World Wind will attempt to connect to the network to retrieve data or for other reasons.
+     * Indicates whether WorldWind will attempt to connect to the network to retrieve data or for other reasons.
      *
-     * @return <code>true</code> if World Wind is in off-line mode, <code>false</code> if not.
+     * @return <code>true</code> if WorldWind is in off-line mode, <code>false</code> if not.
      */
     boolean isOfflineMode();
 
     /**
-     * Indicates whether World Wind should attempt to connect to the network to retrieve data or for other reasons. The
+     * Indicates whether WorldWind should attempt to connect to the network to retrieve data or for other reasons. The
      * default value for this attribute is <code>false</code>, indicating that the network should be used.
      *
-     * @param offlineMode <code>true</code> if World Wind should use the network, <code>false</code> otherwise
+     * @param offlineMode <code>true</code> if WorldWind should use the network, <code>false</code> otherwise
      */
     void setOfflineMode(boolean offlineMode);
 

--- a/src/gov/nasa/worldwind/util/OGLRenderToTextureSupport.java
+++ b/src/gov/nasa/worldwind/util/OGLRenderToTextureSupport.java
@@ -19,7 +19,7 @@ import javax.media.opengl.*;
  * whenever possible. Different GL feature sets result in different approaches to rendering to texture, therefore the
  * caller cannot depend on the mechanism by which OGLRenderToTextureSupport will write pixel values to the destination
  * texture. For this reason, OGLRenderToTextureSupport must be used when the contents of the windowing system buffer
- * (likely the back framebuffer) can be freely modified by OGLRenderToTextureSupport. The World Wind pre-render stage is
+ * (likely the back framebuffer) can be freely modified by OGLRenderToTextureSupport. The WorldWind pre-render stage is
  * a good example of when it is appropriate to use OGLRenderToTextureSupport. Fore more information on the pre-render
  * stage, see {@link gov.nasa.worldwind.render.PreRenderable} and {@link gov.nasa.worldwind.layers.Layer#preRender(gov.nasa.worldwind.render.DrawContext)}.
  * <b>Note:</b> In order to achieve consistent results across all platforms, it is essential to clear the texture's

--- a/src/gov/nasa/worldwind/util/ShapeEditor.java
+++ b/src/gov/nasa/worldwind/util/ShapeEditor.java
@@ -297,7 +297,7 @@ public class ShapeEditor implements SelectListener, PropertyChangeListener
      * @param wwd           the {@link gov.nasa.worldwind.WorldWindow} associated with the specified shape.
      * @param originalShape the shape to edit.
      *
-     * @throws java.lang.IllegalArgumentException if either the specified world window or shape is null.
+     * @throws java.lang.IllegalArgumentException if either the specified WorldWindow or shape is null.
      */
     public ShapeEditor(WorldWindow wwd, Renderable originalShape)
     {
@@ -418,9 +418,9 @@ public class ShapeEditor implements SelectListener, PropertyChangeListener
     }
 
     /**
-     * Indicates the World Window associated with this editor.
+     * Indicates the WorldWindow associated with this editor.
      *
-     * @return the World Window associated with this editor.
+     * @return the WorldWindow associated with this editor.
      */
     public WorldWindow getWwd()
     {

--- a/src/gov/nasa/worldwind/util/gdal/GDALUtils.java
+++ b/src/gov/nasa/worldwind/util/gdal/GDALUtils.java
@@ -1283,7 +1283,7 @@ public class GDALUtils
      *                                  <p/>
      *                                  AVKey.DATA_TYPE required ( valid values: AVKey.INT16, and AVKey.FLOAT32 )
      *                                  <p/>
-     *                                  AVKey.VERSION optional, if missing a default will be used "NASA World Wind"
+     *                                  AVKey.VERSION optional, if missing a default will be used "NASA WorldWind"
      *                                  <p/>
      *                                  AVKey.DISPLAY_NAME, (String) optional, specifies a name of the document/image
      *                                  <p/>

--- a/src/gov/nasa/worldwind/util/tree/Tree.java
+++ b/src/gov/nasa/worldwind/util/tree/Tree.java
@@ -10,7 +10,7 @@ import gov.nasa.worldwind.WWObject;
 import gov.nasa.worldwind.render.OrderedRenderable;
 
 /**
- * A tree of objects, drawn in the World Window, that the user can interact with. How the tree is drawn is determined by
+ * A tree of objects, drawn in the WorldWindow, that the user can interact with. How the tree is drawn is determined by
  * the {@link TreeLayout}.
  *
  * @author pabercrombie

--- a/src/gov/nasa/worldwind/util/tree/package.html
+++ b/src/gov/nasa/worldwind/util/tree/package.html
@@ -10,7 +10,7 @@
     <title>Tree</title>
 </head>
 <body>
-<p>A tree control drawn in the world window. The user can interact with the tree. The basic tree implementation renders
+<p>A tree control drawn in the WorldWindow. The user can interact with the tree. The basic tree implementation renders
    the tree similar to a file browser tree, but other layouts can be provided.</p>
 
 <p>See {@link gov.nasa.worldwindx.examples.util.TreeControl} for an example of using the tree. {@link

--- a/src/gov/nasa/worldwind/view/BasicView.java
+++ b/src/gov/nasa/worldwind/view/BasicView.java
@@ -73,7 +73,7 @@ public class BasicView extends WWObjectImpl implements View
     protected static final double MINIMUM_NEAR_DISTANCE = 1;
     protected static final double MINIMUM_FAR_DISTANCE = 1000;
     /**
-     * The views's default worst-case depth resolution, in meters. May be specified in the World Wind configuration file
+     * The views's default worst-case depth resolution, in meters. May be specified in the WorldWind configuration file
      * as the <code>gov.nasa.worldwind.avkey.DepthResolution</code> property. The default if not specified in the
      * configuration is 3.0 meters.
      */
@@ -664,7 +664,7 @@ public class BasicView extends WWObjectImpl implements View
         }
 
         // Prevent the near clip plane from becoming unnecessarily small. A very small clip plane is not useful for
-        // rendering the World Wind scene, and significantly reduces the depth precision in the majority of the scene.
+        // rendering the WorldWind scene, and significantly reduces the depth precision in the majority of the scene.
         if (nearDistance < MINIMUM_NEAR_DISTANCE)
             nearDistance = MINIMUM_NEAR_DISTANCE;
 
@@ -898,7 +898,7 @@ public class BasicView extends WWObjectImpl implements View
     /**
      * Removes the model-view matrix on top of the matrix stack, and restores the original matrix.
      *
-     * @param dc the current World Wind drawing context on which the original matrix will be restored.
+     * @param dc the current WorldWind drawing context on which the original matrix will be restored.
      *
      * @throws IllegalArgumentException if <code>dc</code> is null, or if the <code>Globe</code> or <code>GL</code>
      *                                  instances in <code>dc</code> are null.

--- a/src/gov/nasa/worldwindx/applications/antenna/AntennaAxes.java
+++ b/src/gov/nasa/worldwindx/applications/antenna/AntennaAxes.java
@@ -423,7 +423,7 @@ public class AntennaAxes extends AbstractShape
         if (this.getElevationAngle() != null)
             baseM = baseM.multiply(Matrix.fromAxisAngle(this.getElevationAngle(), Vec4.UNIT_X));
 
-        // Compute the screen points at which to place the labels. These are all points on the World Wind principal
+        // Compute the screen points at which to place the labels. These are all points on the WorldWind principal
         // axes, not the antenna model's axes. The correct labeling of those takes place below when the labels are
         // drawn. They have the same directions, but in the antenna model WW's Y axis is the model's Z axis, WW's Z
         // axis is the model's X axis, and WW's X axis is the model's Y axis.

--- a/src/gov/nasa/worldwindx/applications/antenna/AntennaViewer.java
+++ b/src/gov/nasa/worldwindx/applications/antenna/AntennaViewer.java
@@ -99,6 +99,6 @@ public class AntennaViewer extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_LONGITUDE, ANTENNA_POSITION.getLongitude().degrees);
         Configuration.setValue(AVKey.INITIAL_ALTITUDE, 30e3);
 
-        ApplicationTemplate.start("World Wind Antenna Gain Visualization", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Antenna Gain Visualization", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/applications/dataimporter/DataInstaller.java
+++ b/src/gov/nasa/worldwindx/applications/dataimporter/DataInstaller.java
@@ -196,7 +196,7 @@ public class DataInstaller extends AVListImpl
                 Thread.yield();
             }
 
-            // Convert the file to a form usable by World Wind components,
+            // Convert the file to a form usable by WorldWind components,
             // according to the specified DataStoreProducer.
             // This throws an exception if production fails for any reason.
             producer.startProduction();

--- a/src/gov/nasa/worldwindx/applications/dataimporter/DataInstallerApp.java
+++ b/src/gov/nasa/worldwindx/applications/dataimporter/DataInstallerApp.java
@@ -91,7 +91,7 @@ public class DataInstallerApp
             southPanel.add(dataInstallerPanel, BorderLayout.CENTER);
             this.getContentPane().add(southPanel, BorderLayout.SOUTH);
 
-            // Create and install the view controls layer and register a controller for it with the World Window.
+            // Create and install the view controls layer and register a controller for it with the WorldWindow.
             ViewControlsLayer viewControlsLayer = new ViewControlsLayer();
             ApplicationTemplate.insertBeforeCompass(getWwd(), viewControlsLayer);
             this.getWwd().addSelectListener(new ViewControlsSelectListener(this.getWwd(), viewControlsLayer));
@@ -125,7 +125,7 @@ public class DataInstallerApp
         if (Configuration.isMacOS())
         {
             System.setProperty("apple.laf.useScreenMenuBar", "true");
-            System.setProperty("com.apple.mrj.application.apple.menu.about.name", "World Wind Application");
+            System.setProperty("com.apple.mrj.application.apple.menu.about.name", "WorldWind Application");
             System.setProperty("com.apple.mrj.application.growbox.intrudes", "false");
         }
         else if (Configuration.isWindowsOS())

--- a/src/gov/nasa/worldwindx/applications/dataimporter/FileSetHighlighter.java
+++ b/src/gov/nasa/worldwindx/applications/dataimporter/FileSetHighlighter.java
@@ -169,7 +169,7 @@ public class FileSetHighlighter implements ListSelectionListener, SelectListener
     @Override
     public void selected(SelectEvent event)
     {
-        // Called when the sector is selected in the World Window. Ensures that the selected data set's entry in the
+        // Called when the sector is selected in the WorldWindow. Ensures that the selected data set's entry in the
         // data set table is visible.
 
         if (!event.getEventAction().equals(SelectEvent.LEFT_CLICK))

--- a/src/gov/nasa/worldwindx/applications/dataimporter/FileStoreDataSet.java
+++ b/src/gov/nasa/worldwindx/applications/dataimporter/FileStoreDataSet.java
@@ -18,7 +18,7 @@ import java.awt.*;
 import java.io.*;
 
 /**
- * Represents one data set within a World Wind filestore.
+ * Represents one data set within a WorldWind filestore.
  *
  * @author tag
  * @version $Id: FileStoreDataSet.java 1180 2013-02-15 18:40:47Z tgaskins $
@@ -150,9 +150,9 @@ public class FileStoreDataSet extends AVListImpl
             return;
 
         // This data configuration came from an existing file from disk, therefore we cannot guarantee that the
-        // current version of World Wind's data installer produced it. This data configuration file may have been
-        // created by a previous version of World Wind, or by another program. Set fallback values for any missing
-        // parameters that World Wind needs to construct a Layer or ElevationModel from this data configuration.
+        // current version of WorldWind's data installer produced it. This data configuration file may have been
+        // created by a previous version of WorldWind, or by another program. Set fallback values for any missing
+        // parameters that WorldWind needs to construct a Layer or ElevationModel from this data configuration.
         setFallbackParams(doc, this.configFilePath, this);
 
         Element domElement = doc.getDocumentElement();

--- a/src/gov/nasa/worldwindx/applications/dataimporter/LayersMenu.java
+++ b/src/gov/nasa/worldwindx/applications/dataimporter/LayersMenu.java
@@ -55,7 +55,7 @@ public class LayersMenu extends JMenu
         // First remove all the existing menu items.
         this.removeAll();
 
-        // Fill the layers panel with the titles of all layers in the world window's current model.
+        // Fill the layers panel with the titles of all layers in the WorldWindow's current model.
         for (Layer layer : wwd.getModel().getLayers())
         {
             if (layer.getValue(AVKey.IGNORE) != null)

--- a/src/gov/nasa/worldwindx/applications/sar/SAR2.java
+++ b/src/gov/nasa/worldwindx/applications/sar/SAR2.java
@@ -741,7 +741,7 @@ public class SAR2 extends JFrame
     private void initComponents()
     {
         //======== this ========
-        setTitle("World Wind Search and Rescue");
+        setTitle("WorldWind Search and Rescue");
         setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
         addWindowListener(new WindowAdapter()
         {
@@ -1145,7 +1145,7 @@ public class SAR2 extends JFrame
                 });
                 helpMenu.add(sarHelp);
 
-                //---- "About [World Wind Search and Rescue Prototype]" ----
+                //---- "About [WorldWind Search and Rescue Prototype]" ----
                 if (!Configuration.isMacOS())
                 {
                     JMenuItem about = new JMenuItem();

--- a/src/gov/nasa/worldwindx/applications/sar/SARAbout.html
+++ b/src/gov/nasa/worldwindx/applications/sar/SARAbout.html
@@ -9,7 +9,7 @@
 <head>
 
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-    <title>NASA World Wind License</title>
+    <title>NASA WorldWind License</title>
 
     <style type="text/css">
         <!--
@@ -40,7 +40,7 @@
 
 <div style="margin:20px">
 
-    <div class="title">NASA World Wind<br>Search and Rescue Prototype</div>
+    <div class="title">NASA WorldWind<br>Search and Rescue Prototype</div>
 
     <div class="version">Version 6.0 (6/8/2009)</div>
 

--- a/src/gov/nasa/worldwindx/applications/sar/SARApp.java
+++ b/src/gov/nasa/worldwindx/applications/sar/SARApp.java
@@ -13,7 +13,7 @@ import gov.nasa.worldwind.Configuration;
  */
 public class SARApp
 {
-    public static final String APP_NAME = "World Wind Search and Rescue Prototype";
+    public static final String APP_NAME = "WorldWind Search and Rescue Prototype";
     public static final String APP_VERSION = "(Version 6.2 released 7/15/2010)";
     public static final String APP_NAME_AND_VERSION = APP_NAME + " " + APP_VERSION;
 

--- a/src/gov/nasa/worldwindx/applications/sar/SARHelp.html
+++ b/src/gov/nasa/worldwindx/applications/sar/SARHelp.html
@@ -21,7 +21,7 @@ img {display: block; margin:6px auto;}
 --></style>
 
 <body>
-<h2>World Wind Search and Rescue Instructions</h2>
+<h2>WorldWind Search and Rescue Instructions</h2>
 
 <h3>Panels and Controls</h3>
 <img src="images/help-application-frame.jpg" alt="SAR Application Frame" />

--- a/src/gov/nasa/worldwindx/applications/sar/config/SAR.properties
+++ b/src/gov/nasa/worldwindx/applications/sar/config/SAR.properties
@@ -5,9 +5,9 @@
 #
 
 #
-# Default World Wind Configuration Properties
-# Specify configuration values here to override World Wind's default values.
-# Lines starting with # are comments and ignored by World Wind.
+# Default WorldWind Configuration Properties
+# Specify configuration values here to override WorldWind's default values.
+# Lines starting with # are comments and ignored by WorldWind.
 #
 # @version $Id: SAR.properties 1958 2014-04-24 19:25:37Z tgaskins $
 #

--- a/src/gov/nasa/worldwindx/applications/sar/segmentplane/SegmentPlaneController.java
+++ b/src/gov/nasa/worldwindx/applications/sar/segmentplane/SegmentPlaneController.java
@@ -215,7 +215,7 @@ public class SegmentPlaneController implements MouseListener, MouseMotionListene
         {
             if (this.active)
             {
-                // Don't update the segment plane here because the World Window current cursor position will not have
+                // Don't update the segment plane here because the WorldWindow current cursor position will not have
                 // been updated to reflect the current mouse position. Wait to update in the position listener, but
                 // consume the event so the View doesn't respond to it.
                 e.consume();

--- a/src/gov/nasa/worldwindx/applications/sar/worldwind-nosa-1.3.html
+++ b/src/gov/nasa/worldwindx/applications/sar/worldwind-nosa-1.3.html
@@ -10,7 +10,7 @@
 
 
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-    <title>NASA World Wind License</title>
+    <title>NASA WorldWind License</title>
 
     <style type="text/css">
         <!--
@@ -61,7 +61,7 @@
 <table border="0" cellpadding="0" cellspacing="0" width="650">
 <tbody>
 <tr>
-<td><p class="style14"><span class="style4"> NASA WORLD WIND </span></p>
+<td><p class="style14"><span class="style4"> NASA WorldWind </span></p>
 
 <p class="style2">Copyright © 2004-2005 United States Government as represented by the Administrator of the National
     Aeronautics and Space Administration. All Rights Reserved.<br> Copyright © 2004-2005 Contributors. All Rights

--- a/src/gov/nasa/worldwindx/applications/sar/worldwind-nosa-1.3.html
+++ b/src/gov/nasa/worldwindx/applications/sar/worldwind-nosa-1.3.html
@@ -61,7 +61,7 @@
 <table border="0" cellpadding="0" cellspacing="0" width="650">
 <tbody>
 <tr>
-<td><p class="style14"><span class="style4"> NASA WorldWind </span></p>
+<td><p class="style14"><span class="style4"> NASA WORLDWIND </span></p>
 
 <p class="style2">Copyright © 2004-2005 United States Government as represented by the Administrator of the National
     Aeronautics and Space Administration. All Rights Reserved.<br> Copyright © 2004-2005 Contributors. All Rights

--- a/src/gov/nasa/worldwindx/applications/worldwindow/WorldWindow.java
+++ b/src/gov/nasa/worldwindx/applications/worldwindow/WorldWindow.java
@@ -29,7 +29,7 @@ public class WorldWindow
             System.setProperty("com.apple.mrj.application.growbox.intrudes", "false");
             String s = Configuration.getStringValue(Constants.APPLICATION_DISPLAY_NAME);
             if (s == null)
-                s = "World Window";
+                s = "WorldWindow";
             System.setProperty("com.apple.mrj.application.apple.menu.about.name", s);
         }
         else if (Configuration.isWindowsOS())

--- a/src/gov/nasa/worldwindx/applications/worldwindow/config/worldwindow.worldwind.xml
+++ b/src/gov/nasa/worldwindx/applications/worldwindow/config/worldwindow.worldwind.xml
@@ -8,7 +8,7 @@
 <!--$Id: worldwindow.worldwind.xml 1171 2013-02-11 21:45:02Z dcollins $-->
 <WorldWindConfiguration version="1">
     <LayerList href="gov/nasa/worldwindx/applications/worldwindow/config/InitialLayerConfiguration.xml"/>
-    <Property name="gov.nasa.worldwindx.applications.worldwindow.ApplicationDisplayName" value="NASA World Window"/>
+    <Property name="gov.nasa.worldwindx.applications.worldwindow.ApplicationDisplayName" value="NASA WorldWindow"/>
     <Property name="gov.nasa.worldwind.avkey.InitialLatitude" value="30"/>
     <Property name="gov.nasa.worldwindx.applications.worldwindow.ToolBarIconSizeProperty" value="52"/>
 </WorldWindConfiguration>

--- a/src/gov/nasa/worldwindx/applications/worldwindow/core/Controller.java
+++ b/src/gov/nasa/worldwindx/applications/worldwindow/core/Controller.java
@@ -31,7 +31,7 @@ public class Controller
 {
     static
     {
-        // The following is required to use Swing menus with the heavyweight canvas used by World Wind.
+        // The following is required to use Swing menus with the heavyweight canvas used by WorldWind.
         ToolTipManager.sharedInstance().setLightWeightPopupEnabled(false);
         JPopupMenu.setDefaultLightWeightPopupEnabled(false);
     }

--- a/src/gov/nasa/worldwindx/applications/worldwindow/core/Version.java
+++ b/src/gov/nasa/worldwindx/applications/worldwindow/core/Version.java
@@ -16,7 +16,7 @@ public class Version
     private static final String MINOR_VALUE = "0";
     private static final String DOT_VALUE = "1";
     private static final String VERSION_NUMBER = MAJOR_VALUE + "." + MINOR_VALUE + "." + DOT_VALUE;
-    private static final String VERSION_NAME = "World Window Alpha";
+    private static final String VERSION_NAME = "WorldWindow Alpha";
     private static final String RELEASE_DATE = "4 April 2010";
 
     public static String getVersion()

--- a/src/gov/nasa/worldwindx/applications/worldwindow/core/WWPanelImpl.java
+++ b/src/gov/nasa/worldwindx/applications/worldwindow/core/WWPanelImpl.java
@@ -29,7 +29,7 @@ public class WWPanelImpl extends AbstractFeature implements WWPanel
 
     public WWPanelImpl(Registry registry)
     {
-        super("World Wind Panel", Constants.WW_PANEL, registry);
+        super("WorldWind Panel", Constants.WW_PANEL, registry);
 
         this.panel = new JPanel(new BorderLayout());
         this.wwd = new WorldWindowGLCanvas();

--- a/src/gov/nasa/worldwindx/applications/worldwindow/features/DataImportUtil.java
+++ b/src/gov/nasa/worldwindx/applications/worldwindow/features/DataImportUtil.java
@@ -82,14 +82,14 @@ public class DataImportUtil
     }
 
     /**
-     * Returns true if the specified input source is non-null and represents a reference to a World Wind .NET LayerSet
+     * Returns true if the specified input source is non-null and represents a reference to a WorldWind .NET LayerSet
      * XML document, and false otherwise. The input source may be one of the following: <ul> <li>{@link String}</li>
      * <li>{@link java.io.File}</li> <li>{@link java.net.URL}</li> <li>{@link java.net.URI}</li> <li>{@link
      * java.io.InputStream}</li> </ul>
      *
-     * @param source the input source reference to test as a World Wind .NET LayerSet document.
+     * @param source the input source reference to test as a WorldWind .NET LayerSet document.
      *
-     * @return true if the input source is a World Wind .NET LayerSet document, and false otherwise.
+     * @return true if the input source is a WorldWind .NET LayerSet document, and false otherwise.
      *
      * @throws IllegalArgumentException if the input source is null.
      */

--- a/src/gov/nasa/worldwindx/applications/worldwindow/features/ImportedDataDialog.java
+++ b/src/gov/nasa/worldwindx/applications/worldwindow/features/ImportedDataDialog.java
@@ -120,7 +120,7 @@ public class ImportedDataDialog extends AbstractFeatureDialog implements Network
 
                     try
                     {
-                        // Import the file into a form usable by World Wind components.
+                        // Import the file into a form usable by WorldWind components.
                         dataConfig = importDataFromFile(ImportedDataDialog.this.dialog, file, fileStore);
                     }
                     catch (Exception e)
@@ -226,9 +226,9 @@ public class ImportedDataDialog extends AbstractFeatureDialog implements Network
                 continue;
 
             // This data configuration came from an existing file from disk, therefore we cannot guarantee that the
-            // current version of World Wind's data importers produced it. This data configuration file may have been
-            // created by a previous version of World Wind, or by another program. Set fallback values for any missing
-            // parameters that World Wind needs to construct a Layer or ElevationModel from this data configuration.
+            // current version of WorldWind's data importers produced it. This data configuration file may have been
+            // created by a previous version of WorldWind, or by another program. Set fallback values for any missing
+            // parameters that WorldWind needs to construct a Layer or ElevationModel from this data configuration.
             AVList params = new AVListImpl();
             setFallbackParams(doc, filename, params);
 
@@ -378,7 +378,7 @@ public class ImportedDataDialog extends AbstractFeatureDialog implements Network
 
         try
         {
-            // Convert the file to a form usable by World Wind components, according to the specified DataStoreProducer.
+            // Convert the file to a form usable by WorldWind components, according to the specified DataStoreProducer.
             // This throws an exception if production fails for any reason.
             producer.startProduction();
         }

--- a/src/gov/nasa/worldwindx/applications/worldwindow/features/ImportedDataPanel.java
+++ b/src/gov/nasa/worldwindx/applications/worldwindow/features/ImportedDataPanel.java
@@ -24,10 +24,10 @@ import java.awt.*;
 import java.awt.event.*;
 
 /**
- * Displays UI components for a set of caller specified imported data, and manages creation of World Wind components
+ * Displays UI components for a set of caller specified imported data, and manages creation of WorldWind components
  * from that data. Callers fill the panel with imported data by invoking {@link #addImportedData(org.w3c.dom.Element,
  * gov.nasa.worldwind.avlist.AVList)}. This adds the UI components for a specified data set (a "Go To" button, and a
- * label description), creates a World Wind component from the DataConfiguration, and adds the component to the World
+ * label description), creates a WorldWind component from the DataConfiguration, and adds the component to the World
  * Window passed to the panel during construction.
  *
  * @author dcollins
@@ -64,10 +64,10 @@ public class ImportedDataPanel extends ShadedPanel
     }
 
     /**
-     * Adds the UI components for the specified imported data to this panel, and adds the World Wind component created
+     * Adds the UI components for the specified imported data to this panel, and adds the WorldWind component created
      * from the data to the WorldWindow passed to this panel during construction.
      *
-     * @param domElement the document which describes a World Wind data configuration.
+     * @param domElement the document which describes a WorldWind data configuration.
      * @param params     the parameter list which overrides or extends information contained in the document.
      *
      * @throws IllegalArgumentException if the Element is null.

--- a/src/gov/nasa/worldwindx/applications/worldwindow/features/StatusPanelImpl.java
+++ b/src/gov/nasa/worldwindx/applications/worldwindow/features/StatusPanelImpl.java
@@ -151,7 +151,7 @@ public class StatusPanelImpl extends AbstractFeature implements StatusPanel, Sel
 
     protected Object lastSelectedObject;
 
-    // Monitors World Wind select events and if the object selected has a status-bar message attached to it, displays
+    // Monitors WorldWind select events and if the object selected has a status-bar message attached to it, displays
     // that message in the status bar. If there is no status-bark message attached to the selected object but there is
     // an external link attached, displays the external-link string.
     public void selected(SelectEvent event)

--- a/src/gov/nasa/worldwindx/applications/worldwindow/features/WMSPanel.java
+++ b/src/gov/nasa/worldwindx/applications/worldwindow/features/WMSPanel.java
@@ -220,7 +220,7 @@ public class WMSPanel extends AbstractFeaturePanel implements TreeModelListener,
             WMSLayerInfo wmsInfo = layerNode.getWmsLayerInfo();
             AVList configParams = wmsInfo.getParams().copy(); // Copy to insulate changes from the caller.
 
-            // Some wms servers are slow, so increase the timeouts and limits used by world wind's retrievers.
+            // Some wms servers are slow, so increase the timeouts and limits used by WorldWind's retrievers.
             configParams.setValue(AVKey.URL_CONNECT_TIMEOUT, 30000);
             configParams.setValue(AVKey.URL_READ_TIMEOUT, 30000);
             configParams.setValue(AVKey.RETRIEVAL_QUEUE_STALE_REQUEST_LIMIT, 60000);

--- a/src/gov/nasa/worldwindx/applications/worldwindow/features/swinglayermanager/ActiveLayersPanel.java
+++ b/src/gov/nasa/worldwindx/applications/worldwindow/features/swinglayermanager/ActiveLayersPanel.java
@@ -192,7 +192,7 @@ public class ActiveLayersPanel extends AbstractFeaturePanel implements ActiveLay
         layerList.replaceAll(newList);
     }
 
-    // Handles reordering of the World Wind layer list via this panel.
+    // Handles reordering of the WorldWind layer list via this panel.
     protected class ReorderListener extends MouseAdapter
     {
         protected JList list;

--- a/src/gov/nasa/worldwindx/applications/worldwindow/features/swinglayermanager/LayerManagerPanel.java
+++ b/src/gov/nasa/worldwindx/applications/worldwindow/features/swinglayermanager/LayerManagerPanel.java
@@ -536,7 +536,7 @@ public class LayerManagerPanel extends AbstractFeaturePanel implements LayerMana
             WMSLayerInfo wmsInfo = layerNode.getWmsLayerInfo();
             AVList configParams = wmsInfo.getParams().copy(); // Copy to insulate changes from the caller.
 
-            // Some wms servers are slow, so increase the timeouts and limits used by world wind's retrievers.
+            // Some wms servers are slow, so increase the timeouts and limits used by WorldWind's retrievers.
             configParams.setValue(AVKey.URL_CONNECT_TIMEOUT, 30000);
             configParams.setValue(AVKey.URL_READ_TIMEOUT, 30000);
             configParams.setValue(AVKey.RETRIEVAL_QUEUE_STALE_REQUEST_LIMIT, 60000);

--- a/src/gov/nasa/worldwindx/applications/worldwindow/features/swinglayermanager/LayerTreeModel.java
+++ b/src/gov/nasa/worldwindx/applications/worldwindow/features/swinglayermanager/LayerTreeModel.java
@@ -151,7 +151,7 @@ public class LayerTreeModel extends DefaultTreeModel
      * aren't already in the tree, and removes layers from the tree if they are labeled internal. It does not remove
      * other layers in the model but missing from the specified layer list. Use {@link #removeNode(Object)} for that.
      *
-     * @param layerList the layerlist to synchronize with, typically the active layer list of the World Window.
+     * @param layerList the layerlist to synchronize with, typically the active layer list of the WorldWindow.
      */
     public void refresh(LayerList layerList)
     {

--- a/src/gov/nasa/worldwindx/examples/AirspaceBuilder.java
+++ b/src/gov/nasa/worldwindx/examples/AirspaceBuilder.java
@@ -32,7 +32,7 @@ import java.util.*;
 import java.util.zip.*;
 
 /**
- * Illustrates runtime construction of 3D extruded polygons and spheres using World Wind <code>{@link Airspace}</code>
+ * Illustrates runtime construction of 3D extruded polygons and spheres using WorldWind <code>{@link Airspace}</code>
  * shapes. This uses a <code>{@link PolygonEditor}</code> and a <code>{@link SphereAirspaceEditor}</code> to enable
  * runtime editing of <code>{@link Polygon}</code> airspace and <code>{@link SphereAirspace}</code> shapes.
  * <p/>
@@ -58,7 +58,7 @@ import java.util.zip.*;
  * <h1>Demo Shapes</h1>
  * <p/>
  * Select <code>File -> Load Demo Shapes</code> to display a set of polygon airspace shapes built with this editor. The
- * data for these shapes is located in the World Wind project under src/gov/nasa/worldwindx/examples/data/AirspaceBuilder-DemoShapes.zip.
+ * data for these shapes is located in the WorldWind project under src/gov/nasa/worldwindx/examples/data/AirspaceBuilder-DemoShapes.zip.
  *
  * @author dcollins
  * @version $Id: AirspaceBuilder.java 2231 2014-08-15 19:03:12Z dcollins $
@@ -1611,6 +1611,6 @@ public class AirspaceBuilder extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Airspace Builder", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Airspace Builder", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/Airspaces.java
+++ b/src/gov/nasa/worldwindx/examples/Airspaces.java
@@ -16,7 +16,7 @@ import gov.nasa.worldwindx.examples.util.RandomShapeAttributes;
 import java.util.Arrays;
 
 /**
- * Illustrates how to configure and display World Wind <code>{@link Airspace}</code> shapes. Airspace shapes are
+ * Illustrates how to configure and display WorldWind <code>{@link Airspace}</code> shapes. Airspace shapes are
  * extruded 3D volumes defined by geographic coordinates and upper- and lower- altitude boundaries. The interior of
  * airspace shapes always conforms to the curvature of the globe, and optionally also conform to the underlying
  * terrain.
@@ -445,7 +445,7 @@ public class Airspaces extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        start("World Wind Airspaces", AppFrame.class);
+        start("WorldWind Airspaces", AppFrame.class);
     }
 
     protected static Iterable<LatLon> makeLatLon(double[] src)

--- a/src/gov/nasa/worldwindx/examples/AlarmIcons.java
+++ b/src/gov/nasa/worldwindx/examples/AlarmIcons.java
@@ -17,7 +17,7 @@ import java.awt.image.*;
 import java.util.ArrayList;
 
 /**
- * Illustrates how to display an icon with an alarm state using a World Wind <code>{@link WWIcon}</code>. This applies a
+ * Illustrates how to display an icon with an alarm state using a WorldWind <code>{@link WWIcon}</code>. This applies a
  * background image to an icon indicating a warning or an urgent condition, then varies the background image's scale
  * factor over time to make it flash or pulse.
  * <p/>
@@ -184,6 +184,6 @@ public class AlarmIcons extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Alarm Icons", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Alarm Icons", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/AnimatedGlobe.java
+++ b/src/gov/nasa/worldwindx/examples/AnimatedGlobe.java
@@ -14,7 +14,7 @@ import gov.nasa.worldwind.geom.*;
 import javax.media.opengl.GLAnimatorControl;
 
 /**
- * Shows how to use a JOGL Animator to animate in World Wind
+ * Shows how to use a JOGL Animator to animate in WorldWind
  *
  * @author tag
  * @version $Id: AnimatedGlobe.java 1893 2014-04-04 04:31:59Z tgaskins $
@@ -70,6 +70,6 @@ public class AnimatedGlobe extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Animated Globe", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Animated Globe", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/AnnotationControls.java
+++ b/src/gov/nasa/worldwindx/examples/AnnotationControls.java
@@ -20,7 +20,7 @@ import java.awt.event.*;
 import java.io.InputStream;
 
 /**
- * Illustrates how to use a World Wind <code>{@link Annotation}</code> with an <code>{@link
+ * Illustrates how to use a WorldWind <code>{@link Annotation}</code> with an <code>{@link
  * AnnotationLayoutManager}</code> to display an Annotation with a simple embedded user interface. The custom Annotation
  * layouts illustrated here can be found in the following example classes: <ul> <li><code>{@link
  * AudioPlayerAnnotation}</code></li> <li><code>{@link SlideShowAnnotation}</code></li> </ul>
@@ -655,6 +655,6 @@ public class AnnotationControls extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Annotation Controls", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Annotation Controls", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/Annotations.java
+++ b/src/gov/nasa/worldwindx/examples/Annotations.java
@@ -26,7 +26,7 @@ import java.awt.image.*;
 import java.net.URL;
 
 /**
- * Illustrates how to use a World Wind <code>{@link Annotation}</code> to display on-screen information to the user in
+ * Illustrates how to use a WorldWind <code>{@link Annotation}</code> to display on-screen information to the user in
  * the form of a text label with an optional image. Annotations may be attached to a geographic position or a point on
  * the screen. They provide support for multi-line text, simple HTML text markup, and many styling attributes such as
  * font face, size and colors, background shape and background image.
@@ -1885,6 +1885,6 @@ public class Annotations extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Annotations", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Annotations", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/ApplicationTemplate.java
+++ b/src/gov/nasa/worldwindx/examples/ApplicationTemplate.java
@@ -124,7 +124,7 @@ public class ApplicationTemplate
                 this.getContentPane().add(this.statsPanel, BorderLayout.EAST);
             }
 
-            // Create and install the view controls layer and register a controller for it with the World Window.
+            // Create and install the view controls layer and register a controller for it with the WorldWindow.
             ViewControlsLayer viewControlsLayer = new ViewControlsLayer();
             insertBeforeCompass(getWwd(), viewControlsLayer);
             this.getWwd().addSelectListener(new ViewControlsSelectListener(this.getWwd(), viewControlsLayer));
@@ -287,7 +287,7 @@ public class ApplicationTemplate
         if (Configuration.isMacOS())
         {
             System.setProperty("apple.laf.useScreenMenuBar", "true");
-            System.setProperty("com.apple.mrj.application.apple.menu.about.name", "World Wind Application");
+            System.setProperty("com.apple.mrj.application.apple.menu.about.name", "WorldWind Application");
             System.setProperty("com.apple.mrj.application.growbox.intrudes", "false");
             System.setProperty("apple.awt.brushMetalLook", "true");
         }
@@ -330,6 +330,6 @@ public class ApplicationTemplate
     {
         // Call the static start method like this from the main method of your derived class.
         // Substitute your application's name for the first argument.
-        ApplicationTemplate.start("World Wind Application", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Application", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/Balloons.java
+++ b/src/gov/nasa/worldwindx/examples/Balloons.java
@@ -17,7 +17,7 @@ import java.awt.*;
 import java.io.InputStream;
 
 /**
- * Illustrates how to use a World Wind <code>{@link Balloon}</code> to display on-screen information to the user in the
+ * Illustrates how to use a WorldWind <code>{@link Balloon}</code> to display on-screen information to the user in the
  * form of a screen-aligned text balloon. There are two abstract balloon types: <code>{@link ScreenBalloon}</code> which
  * displays a balloon at a point on the screen, and <code>{@link GlobeBalloon}</code> which displays a balloon attached
  * to a position on the Globe. For each abstract balloon type, there are two concrete types: AnnotationBalloon which
@@ -73,7 +73,7 @@ public class Balloons extends ApplicationTemplate
             this.makeAnnotationBalloon();
             this.makeBrowserBalloon();
 
-            // Size the World Window to provide enough screen space for the BrowserBalloon, and center the World Window
+            // Size the WorldWindow to provide enough screen space for the BrowserBalloon, and center the WorldWindow
             // on the screen.
             Dimension size = new Dimension(1200, 800);
             this.setPreferredSize(size);
@@ -156,6 +156,6 @@ public class Balloons extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_ALTITUDE, 9500000);
         Configuration.setValue(AVKey.INITIAL_PITCH, 45);
 
-        ApplicationTemplate.start("World Wind Balloons", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Balloons", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/BathymetryRemoval.java
+++ b/src/gov/nasa/worldwindx/examples/BathymetryRemoval.java
@@ -9,7 +9,7 @@ import gov.nasa.worldwind.globes.ElevationModel;
 import gov.nasa.worldwind.terrain.BathymetryFilterElevationModel;
 
 /**
- * Illustrates how to suppress the World Wind <code>{@link gov.nasa.worldwind.globes.Globe}'s</code> bathymetry
+ * Illustrates how to suppress the WorldWind <code>{@link gov.nasa.worldwind.globes.Globe}'s</code> bathymetry
  * (elevations below mean sea level) by using a <code>{@link BathymetryFilterElevationModel}</code>.
  *
  * @author tag
@@ -37,6 +37,6 @@ public class BathymetryRemoval extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Bathymetry Removal", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Bathymetry Removal", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/Boxes.java
+++ b/src/gov/nasa/worldwindx/examples/Boxes.java
@@ -13,7 +13,7 @@ import gov.nasa.worldwind.render.*;
 import gov.nasa.worldwind.render.Box;
 
 /**
- * Illustrates how to use the World Wind <code>{@link Box}</code> rigid shape to display an arbitrarily sized and
+ * Illustrates how to use the WorldWind <code>{@link Box}</code> rigid shape to display an arbitrarily sized and
  * oriented box at a geographic position on the Globe.
  *
  * @author ccrick
@@ -133,6 +133,6 @@ public class Boxes extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Boxes", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Boxes", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/BulkDownload.java
+++ b/src/gov/nasa/worldwindx/examples/BulkDownload.java
@@ -11,7 +11,7 @@ import gov.nasa.worldwind.util.WWUtil;
 import java.awt.*;
 
 /**
- * Illustrates how to use World Wind to retrieve data from layers and elevation models in bulk from a remote source.
+ * Illustrates how to use WorldWind to retrieve data from layers and elevation models in bulk from a remote source.
  * This class uses a <code>{@link gov.nasa.worldwindx.examples.util.SectorSelector}</code> to specify the geographic area
  * to retrieve, then retrieves data for the specified area using the <code>{@link gov.nasa.worldwind.retrieve.BulkRetrievable}</code>
  * interface on layers and elevation models that support it.
@@ -28,7 +28,7 @@ public class BulkDownload extends ApplicationTemplate
             // Add the bulk download control panel.
             this.getControlPanel().add(new BulkDownloadPanel(this.getWwd()), BorderLayout.SOUTH);
 
-            // Size the application window to provide enough screen space for the World Window and the bulk download
+            // Size the application window to provide enough screen space for the WorldWindow and the bulk download
             // panel, then center the application window on the screen.
             Dimension size = new Dimension(1200, 800);
             this.setPreferredSize(size);
@@ -39,6 +39,6 @@ public class BulkDownload extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Bulk Download", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Bulk Download", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/CacheLocationConfiguration.java
+++ b/src/gov/nasa/worldwindx/examples/CacheLocationConfiguration.java
@@ -9,9 +9,9 @@ package gov.nasa.worldwindx.examples;
 import gov.nasa.worldwind.Configuration;
 
 /**
- * Illustrates how to specify a configuration file that specifies alternate locations for the World Wind local cache.
+ * Illustrates how to specify a configuration file that specifies alternate locations for the WorldWind local cache.
  * This example works in conjunction with the companion file CacheLocationConfiguration.xml, which specifies a
- * non-default location for the writable World Wind cache. That file also includes the standard read locations of the
+ * non-default location for the writable WorldWind cache. That file also includes the standard read locations of the
  * cache so that any previously cached data will be found and used.
  *
  * @author tag
@@ -21,11 +21,11 @@ public class CacheLocationConfiguration extends ApplicationTemplate
 {
     public static void main(String[] args)
     {
-        // Prior to starting World Wind, specify the cache configuration file to Configuration.
+        // Prior to starting WorldWind, specify the cache configuration file to Configuration.
         Configuration.setValue(
             "gov.nasa.worldwind.avkey.DataFileStoreConfigurationFileName",
             "gov/nasa/worldwindx/examples/data/CacheLocationConfiguration.xml");
 
-        ApplicationTemplate.start("World Wind Cache Configuration", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Cache Configuration", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/Cones.java
+++ b/src/gov/nasa/worldwindx/examples/Cones.java
@@ -18,7 +18,7 @@ import java.awt.*;
 import java.util.Hashtable;
 
 /**
- * Illustrates how to use the World Wind <code>{@link Cone}</code> rigid shape to display an arbitrarily sized and
+ * Illustrates how to use the WorldWind <code>{@link Cone}</code> rigid shape to display an arbitrarily sized and
  * oriented cone at a geographic position on the Globe.
  *
  * @author ccrick
@@ -205,7 +205,7 @@ public class Cones extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Cones", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Cones", AppFrame.class);
     }
 }
 

--- a/src/gov/nasa/worldwindx/examples/ConfiguringGLRuntimeCapabilities.java
+++ b/src/gov/nasa/worldwindx/examples/ConfiguringGLRuntimeCapabilities.java
@@ -13,10 +13,10 @@ import gov.nasa.worldwind.util.Logging;
 import javax.media.opengl.GLAutoDrawable;
 
 /**
- * Illustrates how to specify the OpenGL features World Wind uses by configuring a <code>{@link
+ * Illustrates how to specify the OpenGL features WorldWind uses by configuring a <code>{@link
  * GLRuntimeCapabilities}</code>. By defining a custom <code>{@link gov.nasa.worldwind.WorldWindowGLDrawable}</code> and
  * setting properties on the GLRuntimeCapabilities attached to its SceneController, applications can specify which
- * OpenGL features World Wind uses during rendering.
+ * OpenGL features WorldWind uses during rendering.
  *
  * @author dcollins
  * @version $Id: ConfiguringGLRuntimeCapabilities.java 3432 2015-10-01 19:40:30Z dcollins $
@@ -26,7 +26,7 @@ public class ConfiguringGLRuntimeCapabilities extends ApplicationTemplate
     static
     {
         // Modify the configuration to specify our custom WorldWindowGLDrawable. Normally, an application would specify
-        // this in a configuration file. For example, via the standard World Wind XML configuration file:
+        // this in a configuration file. For example, via the standard WorldWind XML configuration file:
         //
         //    <WorldWindConfiguration version="1">
         //        ...
@@ -34,7 +34,7 @@ public class ConfiguringGLRuntimeCapabilities extends ApplicationTemplate
         //        ...
         //    </WorldWindConfiguration>
         //
-        // Or via the legacy World Wind properties file:
+        // Or via the legacy WorldWind properties file:
         //
         //    ...
         //    gov.nasa.worldwind.avkey.WorldWindowClassName=MyGLAutoDrawableClassName
@@ -47,7 +47,7 @@ public class ConfiguringGLRuntimeCapabilities extends ApplicationTemplate
     /**
      * Subclass of {@link gov.nasa.worldwind.WorldWindowGLAutoDrawable} which overrides the method {@link
      * gov.nasa.worldwind.WorldWindowGLAutoDrawable#init(javax.media.opengl.GLAutoDrawable)} to configure the OpenGL
-     * features used by the World Wind SDK.
+     * features used by the WorldWind SDK.
      */
     public static class MyGLAutoDrawable extends WorldWindowGLAutoDrawable
     {
@@ -57,7 +57,7 @@ public class ConfiguringGLRuntimeCapabilities extends ApplicationTemplate
         }
 
         /**
-         * Overridden to configure the OpenGL features used by the World Wind SDK. See {@link
+         * Overridden to configure the OpenGL features used by the WorldWind SDK. See {@link
          * javax.media.opengl.GLEventListener#init(GLAutoDrawable)}.
          *
          * @param glAutoDrawable the drawable
@@ -65,12 +65,12 @@ public class ConfiguringGLRuntimeCapabilities extends ApplicationTemplate
         public void init(GLAutoDrawable glAutoDrawable)
         {
             // Invoked when the GL context changes. The host machine capabilities may have changed, so re-configure the
-            // OpenGL features used by the World Wind SDK.
+            // OpenGL features used by the WorldWind SDK.
             super.init(glAutoDrawable);
             this.configureGLRuntimeCaps();
         }
 
-        /** Configures the OpenGL runtime features used by the World Wind SDK. */
+        /** Configures the OpenGL runtime features used by the WorldWind SDK. */
         protected void configureGLRuntimeCaps()
         {
             // Get a reference to the OpenGL Runtime Capabilities associated with this WorldWindow's SceneController.
@@ -90,14 +90,14 @@ public class ConfiguringGLRuntimeCapabilities extends ApplicationTemplate
                 return;
             }
 
-            // Configure which OpenGL features may be used by the World Wind SDK. Configuration values for features
+            // Configure which OpenGL features may be used by the WorldWind SDK. Configuration values for features
             // which are not available on the host machine are ignored. This example shows configuration of the OpenGL
             // framebuffer objects feature.
             glrc.setFramebufferObjectEnabled(this.isEnableFramebufferObjects());
         }
 
         /**
-         * Returns true if the World Wind SDK should enable use of OpenGL framebuffer objects (if available), and false
+         * Returns true if the WorldWind SDK should enable use of OpenGL framebuffer objects (if available), and false
          * otherwise.
          *
          * @return true ot enable use of GL framebuffer objects; false otherwise.
@@ -105,7 +105,7 @@ public class ConfiguringGLRuntimeCapabilities extends ApplicationTemplate
         protected boolean isEnableFramebufferObjects()
         {
             // Applications inject their logic for determining whether or not to enable use of OpenGL framebuffer
-            // objects in the World Wind SDK. If OpenGL framebuffer objects are not available on the host machine,
+            // objects in the WorldWind SDK. If OpenGL framebuffer objects are not available on the host machine,
             // this setting is ignored.
             return false;
         }
@@ -113,6 +113,6 @@ public class ConfiguringGLRuntimeCapabilities extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        start("World Wind Configuring GL Runtime Capabilities", AppFrame.class);
+        start("WorldWind Configuring GL Runtime Capabilities", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/ContextMenusOnShapes.java
+++ b/src/gov/nasa/worldwindx/examples/ContextMenusOnShapes.java
@@ -256,6 +256,6 @@ public class ContextMenusOnShapes extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Context Menus on Shapes", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Context Menus on Shapes", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/ContourBuilderExample.java
+++ b/src/gov/nasa/worldwindx/examples/ContourBuilderExample.java
@@ -138,6 +138,6 @@ public class ContourBuilderExample extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        start("World Wind Contour Building", AppFrame.class);
+        start("WorldWind Contour Building", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/ContourLines.java
+++ b/src/gov/nasa/worldwindx/examples/ContourLines.java
@@ -18,7 +18,7 @@ import java.awt.*;
 import java.util.*;
 
 /**
- * Illustrates how to display contour lines in World Wind on the surface terrain at a specified elevation. This uses the
+ * Illustrates how to display contour lines in WorldWind on the surface terrain at a specified elevation. This uses the
  * class <code>{@link ContourLine}</code> to compute and display the contour lines.
  *
  * @author Patrick Murris
@@ -37,7 +37,7 @@ public class ContourLines extends ApplicationTemplate
             layer.setName("Contour Lines");
             layer.setPickEnabled(false);
 
-            // Add the contour line layer to the World Window and update the layer panel.
+            // Add the contour line layer to the WorldWindow and update the layer panel.
             insertBeforePlacenames(getWwd(), layer);
 
             // Add a global moving contour line to the layer.
@@ -113,6 +113,6 @@ public class ContourLines extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_ALTITUDE, 30000);
         Configuration.setValue(AVKey.INITIAL_PITCH, 45);
 
-        ApplicationTemplate.start("World Wind Contour Lines", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Contour Lines", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/CustomElevationModel.java
+++ b/src/gov/nasa/worldwindx/examples/CustomElevationModel.java
@@ -9,7 +9,7 @@ import gov.nasa.worldwind.Configuration;
 import gov.nasa.worldwind.avlist.AVKey;
 
 /**
- * Illustrates how to configure World Wind with a custom <code>{@link gov.nasa.worldwind.globes.ElevationModel}</code>
+ * Illustrates how to configure WorldWind with a custom <code>{@link gov.nasa.worldwind.globes.ElevationModel}</code>
  * from a configuration file.
  *
  * @author tag
@@ -19,10 +19,10 @@ public class CustomElevationModel extends ApplicationTemplate
 {
     public static void main(String[] args)
     {
-        // Specify the configuration file for the elevation model prior to starting World Wind:
+        // Specify the configuration file for the elevation model prior to starting WorldWind:
         Configuration.setValue(AVKey.EARTH_ELEVATION_MODEL_CONFIG_FILE,
             "gov/nasa/worldwindx/examples/data/CustomElevationModel.xml");
 
-        ApplicationTemplate.start("World Wind Custom Elevation Model", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Custom Elevation Model", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/Cylinders.java
+++ b/src/gov/nasa/worldwindx/examples/Cylinders.java
@@ -19,7 +19,7 @@ import java.awt.*;
 import java.util.Hashtable;
 
 /**
- * Illustrates how to use the World Wind <code>{@link Cylinder}</code> rigid shape to display an arbitrarily sized and
+ * Illustrates how to use the WorldWind <code>{@link Cylinder}</code> rigid shape to display an arbitrarily sized and
  * oriented cylinder at a geographic position on the Globe.
  *
  * @author ccrick
@@ -206,7 +206,7 @@ public class Cylinders extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Cylinders", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Cylinders", AppFrame.class);
     }
 }
 

--- a/src/gov/nasa/worldwindx/examples/DebuggingGLErrors.java
+++ b/src/gov/nasa/worldwindx/examples/DebuggingGLErrors.java
@@ -24,7 +24,7 @@ public class DebuggingGLErrors extends ApplicationTemplate
     static
     {
         // Modify the configuration to specify our custom WorldWindowGLDrawable. Normally, an application would specify
-        // this in a configuration file. For example, via the standard World Wind XML configuration file:
+        // this in a configuration file. For example, via the standard WorldWind XML configuration file:
         //
         //    <WorldWindConfiguration version="1">
         //        ...
@@ -32,7 +32,7 @@ public class DebuggingGLErrors extends ApplicationTemplate
         //        ...
         //    </WorldWindConfiguration>
         //
-        // Or via the legacy World Wind properties file:
+        // Or via the legacy WorldWind properties file:
         //
         //    ...
         //    gov.nasa.worldwind.avkey.WorldWindowClassName=MyGLAutoDrawableClassName
@@ -55,7 +55,7 @@ public class DebuggingGLErrors extends ApplicationTemplate
         }
 
         /**
-         * Overridden to configure the OpenGL features used by the World Wind SDK. See {@link
+         * Overridden to configure the OpenGL features used by the WorldWind SDK. See {@link
          * javax.media.opengl.GLEventListener#init(javax.media.opengl.GLAutoDrawable)}.
          *
          * @param glAutoDrawable the drawable
@@ -63,7 +63,7 @@ public class DebuggingGLErrors extends ApplicationTemplate
         public void init(GLAutoDrawable glAutoDrawable)
         {
             // Invoked when the GL context changes. The host machine capabilities may have changed, so re-configure the
-            // OpenGL features used by the World Wind SDK.
+            // OpenGL features used by the WorldWind SDK.
             super.init(glAutoDrawable);
 
             // Install the OpenGL error debugger. Under normal operation OpenGL errors are silently flagged. This
@@ -76,6 +76,6 @@ public class DebuggingGLErrors extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        start("World Wind Debugging GL Errors", AppFrame.class);
+        start("WorldWind Debugging GL Errors", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/DeepPicking.java
+++ b/src/gov/nasa/worldwindx/examples/DeepPicking.java
@@ -71,6 +71,6 @@ public class DeepPicking extends Airspaces
 
     public static void main(String[] args)
     {
-        start("World Wind Deep Picking", AppFrame.class);
+        start("WorldWind Deep Picking", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/DetailHints.java
+++ b/src/gov/nasa/worldwindx/examples/DetailHints.java
@@ -133,6 +133,6 @@ public class DetailHints extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Detail Hints", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Detail Hints", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/DimGlobeSurface.java
+++ b/src/gov/nasa/worldwindx/examples/DimGlobeSurface.java
@@ -94,6 +94,6 @@ public class DimGlobeSurface extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Surface Dimming", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Surface Dimming", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/DraggingShapes.java
+++ b/src/gov/nasa/worldwindx/examples/DraggingShapes.java
@@ -14,7 +14,7 @@ import java.awt.*;
 import java.util.Arrays;
 
 /**
- * Illustrates how to enable shape dragging in World Wind by using a <code>{@link gov.nasa.worldwind.util.BasicDragger}</code>. This creates
+ * Illustrates how to enable shape dragging in WorldWind by using a <code>{@link gov.nasa.worldwind.util.BasicDragger}</code>. This creates
  * multiple shapes on the surface terrain that can be dragged to a new location on the terrain. The shapes retain their
  * form when dragged.
  *
@@ -29,7 +29,7 @@ public class DraggingShapes extends ApplicationTemplate
 
         public AppFrame()
         {
-            // Add a basic dragger to the World Window's select listeners to enable shape dragging.
+            // Add a basic dragger to the WorldWindow's select listeners to enable shape dragging.
             this.getWwd().addSelectListener(new BasicDragger(this.getWwd()));
 
             // Create a layer of shapes to drag.
@@ -187,6 +187,6 @@ public class DraggingShapes extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Dragging Shapes", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Dragging Shapes", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/EGM96Offsets.java
+++ b/src/gov/nasa/worldwindx/examples/EGM96Offsets.java
@@ -36,6 +36,6 @@ public class EGM96Offsets extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind EGM96 Offsets", AppFrame.class);
+        ApplicationTemplate.start("WorldWind EGM96 Offsets", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/ElevationsAllZero.java
+++ b/src/gov/nasa/worldwindx/examples/ElevationsAllZero.java
@@ -36,6 +36,6 @@ public class ElevationsAllZero
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Zero Elevations", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Zero Elevations", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/Ellipsoids.java
+++ b/src/gov/nasa/worldwindx/examples/Ellipsoids.java
@@ -18,7 +18,7 @@ import java.awt.*;
 import java.util.Hashtable;
 
 /**
- * Illustrates how to use the World Wind <code>{@link Ellipsoid}</code> rigid shape to display an arbitrarily sized and
+ * Illustrates how to use the WorldWind <code>{@link Ellipsoid}</code> rigid shape to display an arbitrarily sized and
  * oriented ellipsoid at a geographic position on the Globe.
  *
  * @author ccrick
@@ -204,6 +204,6 @@ public class Ellipsoids extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Ellipsoids", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Ellipsoids", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/ExportImageOrElevations.java
+++ b/src/gov/nasa/worldwindx/examples/ExportImageOrElevations.java
@@ -529,6 +529,6 @@ public class ExportImageOrElevations extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_LATITUDE, 37.7794d);
         Configuration.setValue(AVKey.INITIAL_LONGITUDE, -122.4192d);
 
-        ApplicationTemplate.start("World Wind Exporting Surface Imagery and Elevations", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Exporting Surface Imagery and Elevations", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/ExtrudedPolygonWithBaseDepth.java
+++ b/src/gov/nasa/worldwindx/examples/ExtrudedPolygonWithBaseDepth.java
@@ -83,6 +83,6 @@ public class ExtrudedPolygonWithBaseDepth extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Extruded Polygon with Base Depth", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Extruded Polygon with Base Depth", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/ExtrudedPolygons.java
+++ b/src/gov/nasa/worldwindx/examples/ExtrudedPolygons.java
@@ -94,6 +94,6 @@ public class ExtrudedPolygons extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Extruded Polygons", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Extruded Polygons", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/ExtrudedPolygonsFromShapefile.java
+++ b/src/gov/nasa/worldwindx/examples/ExtrudedPolygonsFromShapefile.java
@@ -36,7 +36,7 @@ public class ExtrudedPolygonsFromShapefile extends ApplicationTemplate
                         final Layer layer = (Layer) result; // the result is the layer the factory created
                         layer.setName(WWIO.getFilename(layer.getName()));
 
-                        // Add the layer to the World Window's layer list on the Event Dispatch Thread.
+                        // Add the layer to the WorldWindow's layer list on the Event Dispatch Thread.
                         SwingUtilities.invokeLater(new Runnable()
                         {
                             @Override

--- a/src/gov/nasa/worldwindx/examples/ExtrudedShapes.java
+++ b/src/gov/nasa/worldwindx/examples/ExtrudedShapes.java
@@ -23,7 +23,7 @@ import java.util.zip.*;
 
 /**
  * Demonstrates how to create {@link ExtrudedPolygon}s with cap and side textures. The polygon geometry is retrieved
- * from a World Wind data site, as is the image applied to the extruded polygon's sides.
+ * from a WorldWind data site, as is the image applied to the extruded polygon's sides.
  *
  * @author tag
  * @version $Id: ExtrudedShapes.java 2109 2014-06-30 16:52:38Z tgaskins $
@@ -47,7 +47,7 @@ public class ExtrudedShapes extends ApplicationTemplate
                 layer.setName("Extruded Shapes");
                 layer.setPickEnabled(true);
 
-                // Retrieve the geometry from the World Wind demo site.
+                // Retrieve the geometry from the WorldWind demo site.
                 List<Airspace> airspaces = new ArrayList<Airspace>();
                 loadAirspacesFromPath(DEMO_AIRSPACES_PATH, airspaces);
 
@@ -174,6 +174,6 @@ public class ExtrudedShapes extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Extruded Polygons on Ground", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Extruded Polygons on Ground", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/FlatWorld.java
+++ b/src/gov/nasa/worldwindx/examples/FlatWorld.java
@@ -258,6 +258,6 @@ public class FlatWorld extends ApplicationTemplate
     {
         // Adjust configuration values before instantiation
         Configuration.setValue(AVKey.GLOBE_CLASS_NAME, EarthFlat.class.getName());
-        start("World Wind Flat World", AppFrame.class);
+        start("WorldWind Flat World", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/FlatWorldEarthquakes.java
+++ b/src/gov/nasa/worldwindx/examples/FlatWorldEarthquakes.java
@@ -609,6 +609,6 @@ public class FlatWorldEarthquakes extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_LONGITUDE, 0);
         Configuration.setValue(AVKey.INITIAL_ALTITUDE, 50e6);
         Configuration.setValue(AVKey.GLOBE_CLASS_NAME, EarthFlat.class.getName());
-        ApplicationTemplate.start("World Wind USGS Earthquakes M 2.5+ - 7 days", AppFrame.class);
+        ApplicationTemplate.start("WorldWind USGS Earthquakes M 2.5+ - 7 days", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/GARSGraticule.java
+++ b/src/gov/nasa/worldwindx/examples/GARSGraticule.java
@@ -43,6 +43,6 @@ public class GARSGraticule extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind GARS Graticule", AppFrame.class);
+        ApplicationTemplate.start("WorldWind GARS Graticule", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/GPSTracks.java
+++ b/src/gov/nasa/worldwindx/examples/GPSTracks.java
@@ -103,6 +103,6 @@ public class GPSTracks extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Tracks", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Tracks", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/GazetteerApp.java
+++ b/src/gov/nasa/worldwindx/examples/GazetteerApp.java
@@ -30,6 +30,6 @@ public class GazetteerApp extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Gazetteer Example", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Gazetteer Example", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/GazetteerPanel.java
+++ b/src/gov/nasa/worldwindx/examples/GazetteerPanel.java
@@ -43,7 +43,7 @@ public class GazetteerPanel extends JPanel
     /**
      * Create a new panel.
      *
-     * @param wwd                World window to animate when a search is performed.
+     * @param wwd                WorldWindow to animate when a search is performed.
      * @param gazetteerClassName Name of the gazetteer class to instantiate. If this parameter is {@code null} a {@link
      *                           YahooGazetteer} is instantiated.
      *

--- a/src/gov/nasa/worldwindx/examples/GeoRSS.java
+++ b/src/gov/nasa/worldwindx/examples/GeoRSS.java
@@ -113,6 +113,6 @@ public class GeoRSS extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind GeoRSS", AppFrame.class);
+        ApplicationTemplate.start("WorldWind GeoRSS", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/GetBestElevations.java
+++ b/src/gov/nasa/worldwindx/examples/GetBestElevations.java
@@ -146,6 +146,6 @@ public class GetBestElevations extends ApplicationTemplate
     public static void main(String[] args)
     {
         // Adjust configuration values before instantiation
-        ApplicationTemplate.start("World Wind Get Best Elevations", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Get Best Elevations", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/GlobeAnnotationExample.java
+++ b/src/gov/nasa/worldwindx/examples/GlobeAnnotationExample.java
@@ -35,6 +35,6 @@ public class GlobeAnnotationExample extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Globe Annotation", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Globe Annotation", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/Graticule.java
+++ b/src/gov/nasa/worldwindx/examples/Graticule.java
@@ -30,6 +30,6 @@ public class Graticule extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Lat-Lon Graticule", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Lat-Lon Graticule", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/HelloWorldWind.java
+++ b/src/gov/nasa/worldwindx/examples/HelloWorldWind.java
@@ -9,7 +9,7 @@ import gov.nasa.worldwind.*;
 import gov.nasa.worldwind.awt.WorldWindowGLCanvas;
 
 /**
- * This is the most basic World Wind program.
+ * This is the most basic WorldWind program.
  *
  * @version $Id: HelloWorldWind.java 1971 2014-04-29 21:31:28Z dcollins $
  */
@@ -37,7 +37,7 @@ public class HelloWorldWind
     {
         if (Configuration.isMacOS())
         {
-            System.setProperty("com.apple.mrj.application.apple.menu.about.name", "Hello World Wind");
+            System.setProperty("com.apple.mrj.application.apple.menu.about.name", "Hello WorldWind");
         }
 
         java.awt.EventQueue.invokeLater(new Runnable()

--- a/src/gov/nasa/worldwindx/examples/IconPicking.java
+++ b/src/gov/nasa/worldwindx/examples/IconPicking.java
@@ -91,6 +91,6 @@ public class IconPicking extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_ALTITUDE, 27e6);
         Configuration.setValue(AVKey.INITIAL_LATITUDE, 0);
         Configuration.setValue(AVKey.INITIAL_LONGITUDE, 88);
-        ApplicationTemplate.start("World Wind Icon Picking", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Icon Picking", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/LayerTreeUsage.java
+++ b/src/gov/nasa/worldwindx/examples/LayerTreeUsage.java
@@ -50,7 +50,7 @@ public class LayerTreeUsage extends ApplicationTemplate
             // Add a controller to handle input events on the layer tree.
             this.controller = new HotSpotController(this.getWwd());
 
-            // Size the World Window to take up the space typically used by the layer panel. This illustrates the
+            // Size the WorldWindow to take up the space typically used by the layer panel. This illustrates the
             // screen space gained by using the on-screen layer tree.
             Dimension size = new Dimension(1000, 600);
             this.setPreferredSize(size);
@@ -61,6 +61,6 @@ public class LayerTreeUsage extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Layer Tree", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Layer Tree", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/LineBackground.java
+++ b/src/gov/nasa/worldwindx/examples/LineBackground.java
@@ -109,6 +109,6 @@ public class LineBackground extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Line Backgrounds", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Line Backgrounds", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/LineBuilder.java
+++ b/src/gov/nasa/worldwindx/examples/LineBuilder.java
@@ -60,7 +60,7 @@ public class LineBuilder extends AVListImpl
      * Construct a new line builder using the specified polyline and layer and drawing events from the specified world
      * window. Either or both the polyline and the layer may be null, in which case the necessary object is created.
      *
-     * @param wwd       the world window to draw events from.
+     * @param wwd       the WorldWindow to draw events from.
      * @param lineLayer the layer holding the polyline. May be null, in which case a new layer is created.
      * @param polyline  the polyline object to build. May be null, in which case a new polyline is created.
      */
@@ -391,6 +391,6 @@ public class LineBuilder extends AVListImpl
     public static void main(String[] args)
     {
         //noinspection deprecation
-        ApplicationTemplate.start("World Wind Line Builder", LineBuilder.AppFrame.class);
+        ApplicationTemplate.start("WorldWind Line Builder", LineBuilder.AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/LocalDataOnly.java
+++ b/src/gov/nasa/worldwindx/examples/LocalDataOnly.java
@@ -31,7 +31,7 @@ public class LocalDataOnly extends ApplicationTemplate
     {
         ApplicationTemplate.start("Local Data Only", AppFrame.class);
 
-        // Force World Wind not to use the network
+        // Force WorldWind not to use the network
         WorldWind.getNetworkStatus().setOfflineMode(true);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/LoggingControl.java
+++ b/src/gov/nasa/worldwindx/examples/LoggingControl.java
@@ -8,14 +8,14 @@ package gov.nasa.worldwindx.examples;
 import java.util.logging.*;
 
 /**
- * Illustrate control and redirection of World Wind logging.
+ * Illustrate control and redirection of WorldWind logging.
  *
  * @author tag
  * @version $Id: LoggingControl.java 1171 2013-02-11 21:45:02Z dcollins $
  */
 public class LoggingControl extends ApplicationTemplate
 {
-    // Use the standard World Wind application template
+    // Use the standard WorldWind application template
     private static class AppFrame extends ApplicationTemplate.AppFrame
     {
         public AppFrame()
@@ -26,10 +26,10 @@ public class LoggingControl extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        // Get the World Wind logger by name.
+        // Get the WorldWind logger by name.
         Logger logger = Logger.getLogger("gov.nasa.worldwind");
 
-        // Turn off logging to parent handlers of the World Wind handler.
+        // Turn off logging to parent handlers of the WorldWind handler.
         logger.setUseParentHandlers(false);
 
         // Create a console handler (defined below) that we use to write log messages.
@@ -43,7 +43,7 @@ public class LoggingControl extends ApplicationTemplate
         logger.addHandler(handler);
 
         // Start the application.
-        ApplicationTemplate.start("World Wind Logging Control", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Logging Control", AppFrame.class);
     }
 
     private static class MyHandler extends ConsoleHandler

--- a/src/gov/nasa/worldwindx/examples/MGRSGraticule.java
+++ b/src/gov/nasa/worldwindx/examples/MGRSGraticule.java
@@ -53,6 +53,6 @@ public class MGRSGraticule extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind UTM/MGRS Graticule", AppFrame.class);
+        ApplicationTemplate.start("WorldWind UTM/MGRS Graticule", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/Markers.java
+++ b/src/gov/nasa/worldwindx/examples/Markers.java
@@ -133,6 +133,6 @@ public class Markers extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Markers", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Markers", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/MarkersOrder.java
+++ b/src/gov/nasa/worldwindx/examples/MarkersOrder.java
@@ -558,6 +558,6 @@ public class MarkersOrder extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_LATITUDE, TRACK_LATITUDE);
         Configuration.setValue(AVKey.INITIAL_LONGITUDE, TRACK_LONGITUDE);
         Configuration.setValue(AVKey.INITIAL_ALTITUDE, 40e3);
-        ApplicationTemplate.start("World Wind Markers Order", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Markers Order", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/MeasureToolUsage.java
+++ b/src/gov/nasa/worldwindx/examples/MeasureToolUsage.java
@@ -127,7 +127,7 @@ public class MeasureToolUsage extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Measure Tool", MeasureToolUsage.AppFrame.class);
+        ApplicationTemplate.start("WorldWind Measure Tool", MeasureToolUsage.AppFrame.class);
     }
 
 }

--- a/src/gov/nasa/worldwindx/examples/MultiResPath.java
+++ b/src/gov/nasa/worldwindx/examples/MultiResPath.java
@@ -102,6 +102,6 @@ public class MultiResPath extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind UAVPath Test", AppFrame.class);
+        ApplicationTemplate.start("WorldWind UAVPath Test", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/NetworkOfflineMode.java
+++ b/src/gov/nasa/worldwindx/examples/NetworkOfflineMode.java
@@ -14,7 +14,7 @@ import java.awt.*;
 import java.awt.event.*;
 
 /**
- * Shows how to detach World Wind from the network and reattach it.
+ * Shows how to detach WorldWind from the network and reattach it.
  *
  * @author tag
  * @version $Id: NetworkOfflineMode.java 2109 2014-06-30 16:52:38Z tgaskins $

--- a/src/gov/nasa/worldwindx/examples/OnScreenLayerManager.java
+++ b/src/gov/nasa/worldwindx/examples/OnScreenLayerManager.java
@@ -31,6 +31,6 @@ public class OnScreenLayerManager extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind On-Screen Layer Manager", AppFrame.class);
+        ApplicationTemplate.start("WorldWind On-Screen Layer Manager", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/OpenGLSupportTest.java
+++ b/src/gov/nasa/worldwindx/examples/OpenGLSupportTest.java
@@ -10,7 +10,7 @@ import javax.media.opengl.*;
 import javax.media.opengl.awt.GLCanvas;
 
 /**
- * Determines whether a device supports the OpenGL features necessary for World Wind.
+ * Determines whether a device supports the OpenGL features necessary for WorldWind.
  *
  * @author tag
  * @version $Id: OpenGLSupportTest.java 1675 2013-10-18 00:32:15Z tgaskins $

--- a/src/gov/nasa/worldwindx/examples/ParallelPaths.java
+++ b/src/gov/nasa/worldwindx/examples/ParallelPaths.java
@@ -104,6 +104,6 @@ public class ParallelPaths extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_LONGITUDE, -122.78);
         Configuration.setValue(AVKey.INITIAL_ALTITUDE, 8000);
 
-        ApplicationTemplate.start("World Wind Multi Path", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Multi Path", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/PathPositionColors.java
+++ b/src/gov/nasa/worldwindx/examples/PathPositionColors.java
@@ -137,6 +137,6 @@ public class PathPositionColors extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_LONGITUDE, -122.3137);
         Configuration.setValue(AVKey.INITIAL_ALTITUDE, 3000);
 
-        ApplicationTemplate.start("World Wind Path Position Colors", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Path Position Colors", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/Paths.java
+++ b/src/gov/nasa/worldwindx/examples/Paths.java
@@ -91,6 +91,6 @@ public class Paths extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Paths", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Paths", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/PathsWithDirection.java
+++ b/src/gov/nasa/worldwindx/examples/PathsWithDirection.java
@@ -70,6 +70,6 @@ public class PathsWithDirection extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_LONGITUDE, -122.77);
         Configuration.setValue(AVKey.INITIAL_ALTITUDE, 22000);
 
-        ApplicationTemplate.start("World Wind Paths With Direction", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Paths With Direction", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/PathsWithLabels.java
+++ b/src/gov/nasa/worldwindx/examples/PathsWithLabels.java
@@ -111,7 +111,7 @@ public class PathsWithLabels extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_LONGITUDE, -122.95);
         Configuration.setValue(AVKey.INITIAL_ALTITUDE, 70000);
 
-        start("World Wind Paths with Labels", AppFrame.class);
+        start("WorldWind Paths with Labels", AppFrame.class);
     }
 
     // Boundary data for San Juan and Snohomish Counties take from

--- a/src/gov/nasa/worldwindx/examples/PersistSessionState.java
+++ b/src/gov/nasa/worldwindx/examples/PersistSessionState.java
@@ -22,7 +22,7 @@ public class PersistSessionState extends ApplicationTemplate
     public static class AppFrame extends ApplicationTemplate.AppFrame
     {
         /**
-         * Create a SessionState utility to load and save World Wind's layer and view state to the default location.
+         * Create a SessionState utility to load and save WorldWind's layer and view state to the default location.
          * Initialized to a new SessionState with its session key set to this application's class name.
          */
         protected SessionState sessionState = new SessionState(PersistSessionState.class.getName());
@@ -103,6 +103,6 @@ public class PersistSessionState extends ApplicationTemplate
             System.setProperty("apple.eawt.quitStrategy", "CLOSE_ALL_WINDOWS");
         }
 
-        start("World Wind Persist Session State", AppFrame.class);
+        start("WorldWind Persist Session State", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/PickFrustum.java
+++ b/src/gov/nasa/worldwindx/examples/PickFrustum.java
@@ -341,6 +341,6 @@ public class PickFrustum extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Picking Frustum", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Picking Frustum", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/PlaceNames.java
+++ b/src/gov/nasa/worldwindx/examples/PlaceNames.java
@@ -35,6 +35,6 @@ public class PlaceNames extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Place Names", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Place Names", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/PlacemarkDecluttering.java
+++ b/src/gov/nasa/worldwindx/examples/PlacemarkDecluttering.java
@@ -242,6 +242,6 @@ public class PlacemarkDecluttering extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Placemark Decluttering", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Placemark Decluttering", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/PlacemarkLabelEditing.java
+++ b/src/gov/nasa/worldwindx/examples/PlacemarkLabelEditing.java
@@ -85,6 +85,6 @@ public class PlacemarkLabelEditing extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Placemark Label Editing", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Placemark Label Editing", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/Placemarks.java
+++ b/src/gov/nasa/worldwindx/examples/Placemarks.java
@@ -232,7 +232,7 @@ public class Placemarks extends ApplicationTemplate
         params.setValue(AVKey.COLOR, Color.WHITE);
         final BufferedImage highlightImage = iconRetriever.createIcon("SFAPMFQM--GIUSA", params);
 
-        // Add the placemark to World Wind on the event dispatch thread.
+        // Add the placemark to WorldWind on the event dispatch thread.
         SwingUtilities.invokeLater(new Runnable()
         {
             @Override
@@ -274,6 +274,6 @@ public class Placemarks extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Placemarks", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Placemarks", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/Polygons.java
+++ b/src/gov/nasa/worldwindx/examples/Polygons.java
@@ -138,6 +138,6 @@ public class Polygons extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Polygons", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Polygons", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/Pyramids.java
+++ b/src/gov/nasa/worldwindx/examples/Pyramids.java
@@ -135,6 +135,6 @@ public class Pyramids extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Pyramids", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Pyramids", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/RemoteSurfaceImage.java
+++ b/src/gov/nasa/worldwindx/examples/RemoteSurfaceImage.java
@@ -12,7 +12,7 @@ import gov.nasa.worldwind.render.SurfaceImage;
 /**
  * This example demonstrates how to retrieve a remote image and display it as a {@link
  * gov.nasa.worldwind.render.SurfaceImage}. <code>SurfaceImage</code> downloads the image in a separate thread via the
- * World Wind retrieval service. Once the image is retrieved, <code>SurfaceImage</code> renders it on the globe.
+ * WorldWind retrieval service. Once the image is retrieved, <code>SurfaceImage</code> renders it on the globe.
  *
  * @author dcollins
  * @version $Id: RemoteSurfaceImage.java 2109 2014-06-30 16:52:38Z tgaskins $
@@ -40,6 +40,6 @@ public class RemoteSurfaceImage extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Remote Surface Image", RemoteSurfaceImage.AppFrame.class);
+        ApplicationTemplate.start("WorldWind Remote Surface Image", RemoteSurfaceImage.AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/RigidShapes.java
+++ b/src/gov/nasa/worldwindx/examples/RigidShapes.java
@@ -158,6 +158,6 @@ public class RigidShapes extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Rigid Shapes", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Rigid Shapes", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/RubberSheetImage.java
+++ b/src/gov/nasa/worldwindx/examples/RubberSheetImage.java
@@ -522,6 +522,6 @@ public class RubberSheetImage extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Rubber Sheet Image", RubberSheetImage.AppFrame.class);
+        ApplicationTemplate.start("WorldWind Rubber Sheet Image", RubberSheetImage.AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/ScankortDenmark.java
+++ b/src/gov/nasa/worldwindx/examples/ScankortDenmark.java
@@ -14,7 +14,7 @@ import gov.nasa.worldwind.terrain.*;
 
 /**
  * This example demonstrates high resolution imagery (0.2 meters per pixel) and elevation data (1.6 meters per pixel)
- * served by the World Wind WMS, and visualized by the World Wind Java client.
+ * served by the WorldWind WMS, and visualized by the WorldWind Java client.
  * <p/>
  * The data is from Denmark.  Details for loading the imagery can be found in: config/Earth/ScankortDenmarkImageLayer.xml
  * while information for loading the elevation data is in: config/Earth/ScankortDenmarkDSMElevationModel.xml.

--- a/src/gov/nasa/worldwindx/examples/ScreenSelection.java
+++ b/src/gov/nasa/worldwindx/examples/ScreenSelection.java
@@ -198,7 +198,7 @@ public class ScreenSelection extends ApplicationTemplate
                 }
             }
 
-            // We've potentially changed the highlight state of one or more objects. Request that the world window
+            // We've potentially changed the highlight state of one or more objects. Request that the WorldWindow
             // redraw itself in order to refresh these object's display. This is necessary because changes in the
             // objects in the pick rectangle do not necessarily correspond to mouse movements. For example, the pick
             // rectangle may be cleared when the user releases the mouse button at the end of a drag. In this case,
@@ -209,6 +209,6 @@ public class ScreenSelection extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        start("World Wind Screen Selection", AppFrame.class);
+        start("WorldWind Screen Selection", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/ShapeClipping.java
+++ b/src/gov/nasa/worldwindx/examples/ShapeClipping.java
@@ -22,7 +22,7 @@ import java.awt.event.*;
 
 /**
  * Shows how to use the {@link gov.nasa.worldwind.util.combine.Combinable} interface and the {@link
- * gov.nasa.worldwind.util.combine.ShapeCombiner} class to compute the intersection of a World Wind surface shapes with
+ * gov.nasa.worldwind.util.combine.ShapeCombiner} class to compute the intersection of a WorldWind surface shapes with
  * Earth's land and water.
  * <p/>
  * This example provides an editable surface circle indicating a region to clip against either land or water. The land
@@ -172,6 +172,6 @@ public class ShapeClipping extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        start("World Wind Shape Clipping", AppFrame.class);
+        start("WorldWind Shape Clipping", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/ShapeCombining.java
+++ b/src/gov/nasa/worldwindx/examples/ShapeCombining.java
@@ -15,7 +15,7 @@ import gov.nasa.worldwind.util.combine.ShapeCombiner;
 
 /**
  * Shows how to use the {@link gov.nasa.worldwind.util.combine.Combinable} interface and the {@link
- * gov.nasa.worldwind.util.combine.ShapeCombiner} class to combine World Wind surface shapes into a complex set of
+ * gov.nasa.worldwind.util.combine.ShapeCombiner} class to combine WorldWind surface shapes into a complex set of
  * contours by using boolean operations.
  * <p/>
  * This example creates two static SurfaceCircle instances that partially overlap and displays them in a layer named
@@ -89,6 +89,6 @@ public class ShapeCombining extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        start("World Wind Shape Combining", AppFrame.class);
+        start("WorldWind Shape Combining", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/ShapeEditing.java
+++ b/src/gov/nasa/worldwindx/examples/ShapeEditing.java
@@ -290,6 +290,6 @@ public class ShapeEditing extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Shape Editing", ShapeEditing.AppFrame.class);
+        ApplicationTemplate.start("WorldWind Shape Editing", ShapeEditing.AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/ShapeEditingExtension.java
+++ b/src/gov/nasa/worldwindx/examples/ShapeEditingExtension.java
@@ -375,7 +375,7 @@ public class ShapeEditingExtension extends ApplicationTemplate
             // Receive selection event to determine when to place the shape in editing mode.
             this.getWwd().addSelectListener(this);
 
-            // Create the custom shape, add it to a layer and add the layer to the World Window's layer list.
+            // Create the custom shape, add it to a layer and add the layer to the WorldWindow's layer list.
             RenderableLayer layer = new RenderableLayer();
 
             ShapeAttributes attrs = new BasicShapeAttributes();
@@ -465,6 +465,6 @@ public class ShapeEditingExtension extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Shape Editing Extension", ShapeEditingExtension.AppFrame.class);
+        ApplicationTemplate.start("WorldWind Shape Editing Extension", ShapeEditingExtension.AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/ShapefileAttributeGroups.java
+++ b/src/gov/nasa/worldwindx/examples/ShapefileAttributeGroups.java
@@ -166,6 +166,6 @@ public class ShapefileAttributeGroups extends ApplicationTemplate
     {
         Configuration.setValue(AVKey.INITIAL_LATITUDE, 30);
         Configuration.setValue(AVKey.INITIAL_LONGITUDE, 30);
-        start("World Wind Shapefile Attribute Groups", AppFrame.class);
+        start("WorldWind Shapefile Attribute Groups", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/ShapefileViewer.java
+++ b/src/gov/nasa/worldwindx/examples/ShapefileViewer.java
@@ -20,8 +20,8 @@ import java.awt.event.*;
 import java.io.File;
 
 /**
- * Illustrates how to import ESRI Shapefiles into World Wind. This uses a <code>{@link ShapefileLayerFactory}</code> to
- * parse a Shapefile's contents and convert the shapefile into an equivalent World Wind shape. This provides examples of
+ * Illustrates how to import ESRI Shapefiles into WorldWind. This uses a <code>{@link ShapefileLayerFactory}</code> to
+ * parse a Shapefile's contents and convert the shapefile into an equivalent WorldWind shape. This provides examples of
  * importing a Shapefile on the local hard drive and importing a Shapefile at a remote URL.
  *
  * @author Patrick Murris
@@ -148,6 +148,6 @@ public class ShapefileViewer extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        start("World Wind Shapefile Viewer", AppFrame.class);
+        start("WorldWind Shapefile Viewer", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/Shapefiles.java
+++ b/src/gov/nasa/worldwindx/examples/Shapefiles.java
@@ -13,8 +13,8 @@ import gov.nasa.worldwindx.examples.util.RandomShapeAttributes;
 import javax.swing.*;
 
 /**
- * Illustrates how to import ESRI Shapefiles into World Wind. This uses a <code>{@link ShapefileLayerFactory}</code> to
- * parse a Shapefile's contents and convert the shapefile into an equivalent World Wind shape.
+ * Illustrates how to import ESRI Shapefiles into WorldWind. This uses a <code>{@link ShapefileLayerFactory}</code> to
+ * parse a Shapefile's contents and convert the shapefile into an equivalent WorldWind shape.
  *
  * @version $Id: Shapefiles.java 3212 2015-06-18 02:45:56Z tgaskins $
  */
@@ -48,7 +48,7 @@ public class Shapefiles extends ApplicationTemplate
                         final Layer layer = (Layer) result; // the result is the layer the factory created
                         layer.setName(WWIO.getFilename(layer.getName()));
 
-                        // Add the layer to the World Window's layer list on the Event Dispatch Thread.
+                        // Add the layer to the WorldWindow's layer list on the Event Dispatch Thread.
                         SwingUtilities.invokeLater(new Runnable()
                         {
                             @Override
@@ -70,6 +70,6 @@ public class Shapefiles extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        start("World Wind Shapefiles", AppFrame.class);
+        start("WorldWind Shapefiles", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/Shapes.java
+++ b/src/gov/nasa/worldwindx/examples/Shapes.java
@@ -704,7 +704,7 @@ public class Shapes
         }
     }
 
-    private static final String APP_NAME = "World Wind Shapes";
+    private static final String APP_NAME = "WorldWind Shapes";
 
     static
     {

--- a/src/gov/nasa/worldwindx/examples/Shutdown.java
+++ b/src/gov/nasa/worldwindx/examples/Shutdown.java
@@ -14,7 +14,7 @@ import java.awt.*;
 import java.awt.event.*;
 
 /**
- * Shows how to shut down a {@link WorldWindow} and how to shut down all of World Wind.
+ * Shows how to shut down a {@link WorldWindow} and how to shut down all of WorldWind.
  *
  * @author tag
  * @version $Id: Shutdown.java 1171 2013-02-11 21:45:02Z dcollins $
@@ -109,7 +109,7 @@ public class Shutdown
         {
             public ShutdownWorldWindAction()
             {
-                super("Shutdown World Wind");
+                super("Shutdown WorldWind");
             }
 
             public void actionPerformed(ActionEvent e)
@@ -125,7 +125,7 @@ public class Shutdown
     {
         if (Configuration.isMacOS())
         {
-            System.setProperty("com.apple.mrj.application.apple.menu.about.name", "Shutdown World Wind");
+            System.setProperty("com.apple.mrj.application.apple.menu.about.name", "Shutdown WorldWind");
         }
 
         java.awt.EventQueue.invokeLater(new Runnable()

--- a/src/gov/nasa/worldwindx/examples/SplitPaneUsage.java
+++ b/src/gov/nasa/worldwindx/examples/SplitPaneUsage.java
@@ -17,7 +17,7 @@ import javax.swing.border.*;
 import java.awt.*;
 
 /**
- * Illustrates how to use World Wind within a Swing JSplitPane. Doing so is mostly straightforward, but in order to work
+ * Illustrates how to use WorldWind within a Swing JSplitPane. Doing so is mostly straightforward, but in order to work
  * around a Swing bug the WorldWindow must be placed within a JPanel and that JPanel's minimum preferred size must be
  * set to zero (both width and height). See the code that does this in the first few lines of the AppPanel constructor
  * below.
@@ -125,7 +125,7 @@ public class SplitPaneUsage
 
     public static void main(String[] args)
     {
-        start("World Wind Split Pane Usage");
+        start("WorldWind Split Pane Usage");
     }
 
     public static void start(String appName)

--- a/src/gov/nasa/worldwindx/examples/Stereo.java
+++ b/src/gov/nasa/worldwindx/examples/Stereo.java
@@ -31,6 +31,6 @@ public class Stereo extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_HEADING, 342);
         Configuration.setValue(AVKey.INITIAL_PITCH, 80);
 
-        ApplicationTemplate.start("World Wind Anaglyph Stereo", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Anaglyph Stereo", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/SurfaceImageViewer.java
+++ b/src/gov/nasa/worldwindx/examples/SurfaceImageViewer.java
@@ -175,6 +175,6 @@ public class SurfaceImageViewer extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Surface Images", SurfaceImageViewer.AppFrame.class);
+        ApplicationTemplate.start("WorldWind Surface Images", SurfaceImageViewer.AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/SurfaceImages.java
+++ b/src/gov/nasa/worldwindx/examples/SurfaceImages.java
@@ -83,6 +83,6 @@ public class SurfaceImages extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Surface Images", SurfaceImages.AppFrame.class);
+        ApplicationTemplate.start("WorldWind Surface Images", SurfaceImages.AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/SurfaceShapes.java
+++ b/src/gov/nasa/worldwindx/examples/SurfaceShapes.java
@@ -6,7 +6,7 @@
 package gov.nasa.worldwindx.examples;
 
 /**
- * Illustrates how to configure and display World Wind <code>{@link gov.nasa.worldwind.render.SurfaceShape}s</code>.
+ * Illustrates how to configure and display WorldWind <code>{@link gov.nasa.worldwind.render.SurfaceShape}s</code>.
  * Surface shapes are used to visualize flat standard shapes types that follow the terrain. This illustrates how to use
  * all 7 standard surface shape types:
  * <p/>
@@ -23,6 +23,6 @@ public class SurfaceShapes extends DraggingShapes
 {
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Surface Shapes", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Surface Shapes", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/SurfaceTextUsage.java
+++ b/src/gov/nasa/worldwindx/examples/SurfaceTextUsage.java
@@ -41,6 +41,6 @@ public class SurfaceTextUsage extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_LONGITUDE, -120.1670);
         Configuration.setValue(AVKey.INITIAL_ALTITUDE, 50000);
 
-        ApplicationTemplate.start("World Wind Surface Text", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Surface Text", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/TabbedPaneUsage.java
+++ b/src/gov/nasa/worldwindx/examples/TabbedPaneUsage.java
@@ -32,7 +32,7 @@ public class TabbedPaneUsage
         if (Configuration.isMacOS())
         {
             System.setProperty("apple.laf.useScreenMenuBar", "true");
-            System.setProperty("com.apple.mrj.application.apple.menu.about.name", "World Wind Tabbed Pane Application");
+            System.setProperty("com.apple.mrj.application.apple.menu.about.name", "WorldWind Tabbed Pane Application");
             System.setProperty("com.apple.mrj.application.growbox.intrudes", "false");
         }
     }
@@ -123,7 +123,7 @@ public class TabbedPaneUsage
         {
             JFrame mainFrame = new JFrame();
 
-            mainFrame.setTitle("World Wind Tabbed Pane");
+            mainFrame.setTitle("WorldWind Tabbed Pane");
             mainFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
             final JTabbedPane tabbedPane = new JTabbedPane();

--- a/src/gov/nasa/worldwindx/examples/TerrainIntersections.java
+++ b/src/gov/nasa/worldwindx/examples/TerrainIntersections.java
@@ -209,7 +209,7 @@ public class TerrainIntersections extends ApplicationTemplate
                 return;
             this.lastTime = System.currentTimeMillis();
 
-            // On the EDT, update the progress bar and if calculations are complete, update the World Window.
+            // On the EDT, update the progress bar and if calculations are complete, update the WorldWindow.
             SwingUtilities.invokeLater(new Runnable()
             {
                 public void run()
@@ -228,7 +228,7 @@ public class TerrainIntersections extends ApplicationTemplate
             });
         }
 
-        /** Updates the World Wind model with the new intersection locations and sight lines. */
+        /** Updates the WorldWind model with the new intersection locations and sight lines. */
         protected void showResults()
         {
             this.showIntersections(firstIntersectionPositions);
@@ -540,6 +540,6 @@ public class TerrainIntersections extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_LONGITUDE, -119.7761d);
 
         // Adjust configuration values before instantiation
-        ApplicationTemplate.start("World Wind Terrain Intersections", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Terrain Intersections", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/TerrainProfiler.java
+++ b/src/gov/nasa/worldwindx/examples/TerrainProfiler.java
@@ -257,6 +257,6 @@ public class TerrainProfiler extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Terrain Profiler", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Terrain Profiler", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/TreeFiltering.java
+++ b/src/gov/nasa/worldwindx/examples/TreeFiltering.java
@@ -131,6 +131,6 @@ public class TreeFiltering extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Filtering by Region", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Filtering by Region", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/VPFLayerDemo.java
+++ b/src/gov/nasa/worldwindx/examples/VPFLayerDemo.java
@@ -17,13 +17,13 @@ import java.awt.event.*;
 import java.io.File;
 
 /**
- * Illustrates how to import data from a Vector Product Format (VPF) database into World Wind. This uses <code>{@link
+ * Illustrates how to import data from a Vector Product Format (VPF) database into WorldWind. This uses <code>{@link
  * VPFLayer}</code> to display an imported VPF database, and uses <code>{@link VPFCoveragePanel}</code> to enable the
  * user to choose which shapes from the VPF database to display.
  * <p/>
  * To display VPF shapes with the appropriate color, style, and icon, applications must include the JAR file
  * <code>vpf-symbols.jar</code> in the Java class-path. If this JAR file is not in the Java class-path, VPFLayer outputs
- * the following message in the World Wind log: <code>WARNING: GeoSym style support is disabled</code>. In this case,
+ * the following message in the WorldWind log: <code>WARNING: GeoSym style support is disabled</code>. In this case,
  * VPF shapes are displayed as gray outlines, and icons are displayed as a gray question mark.
  *
  * @author dcollins
@@ -120,6 +120,6 @@ public class VPFLayerDemo extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        start("World Wind VPF Shapes", AppFrame.class);
+        start("WorldWind VPF Shapes", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/VideoOnTerrain.java
+++ b/src/gov/nasa/worldwindx/examples/VideoOnTerrain.java
@@ -169,6 +169,6 @@ public class VideoOnTerrain extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_LATITUDE, 37.8432);
         Configuration.setValue(AVKey.INITIAL_LONGITUDE, -105.0527);
         Configuration.setValue(AVKey.INITIAL_ALTITUDE, 7000);
-        ApplicationTemplate.start("World Wind Video on Terrain", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Video on Terrain", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/ViewControls.java
+++ b/src/gov/nasa/worldwindx/examples/ViewControls.java
@@ -182,6 +182,6 @@ public class ViewControls extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind View Controls", AppFrame.class);
+        ApplicationTemplate.start("WorldWind View Controls", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/ViewIteration.java
+++ b/src/gov/nasa/worldwindx/examples/ViewIteration.java
@@ -221,7 +221,7 @@ public class ViewIteration extends ApplicationTemplate
         try
         {
             AppFrame frame = new AppFrame();
-            frame.setTitle("World Wind View Paths");
+            frame.setTitle("WorldWind View Paths");
             frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
             frame.setVisible(true);
         }

--- a/src/gov/nasa/worldwindx/examples/ViewLookAround.java
+++ b/src/gov/nasa/worldwindx/examples/ViewLookAround.java
@@ -199,6 +199,6 @@ public class ViewLookAround extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind View Look Around", AppFrame.class);
+        ApplicationTemplate.start("WorldWind View Look Around", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/WCSElevations.java
+++ b/src/gov/nasa/worldwindx/examples/WCSElevations.java
@@ -69,7 +69,7 @@ public class WCSElevations extends ApplicationTemplate
             this.tabbedPane.setSelectedIndex(this.tabbedPane.getTabCount() > 0 ? 1 : 0);
             this.previousTabIndex = this.tabbedPane.getSelectedIndex();
 
-            // Add the tabbed pane to a frame separate from the world window.
+            // Add the tabbed pane to a frame separate from the WorldWindow.
             JFrame controlFrame = new JFrame();
             controlFrame.getContentPane().add(tabbedPane);
             controlFrame.pack();
@@ -101,6 +101,6 @@ public class WCSElevations extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind WCS Layers", AppFrame.class);
+        ApplicationTemplate.start("WorldWind WCS Layers", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/WMSLayerManager.java
+++ b/src/gov/nasa/worldwindx/examples/WMSLayerManager.java
@@ -69,7 +69,7 @@ public class WMSLayerManager
             this.tabbedPane.setSelectedIndex(this.tabbedPane.getTabCount() > 0 ? 1 : 0);
             this.previousTabIndex = this.tabbedPane.getSelectedIndex();
 
-            // Add the tabbed pane to a frame separate from the world window.
+            // Add the tabbed pane to a frame separate from the WorldWindow.
             JFrame controlFrame = new JFrame();
             controlFrame.getContentPane().add(tabbedPane);
             controlFrame.pack();
@@ -101,6 +101,6 @@ public class WMSLayerManager
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind WMS Layers", AppFrame.class);
+        ApplicationTemplate.start("WorldWind WMS Layers", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/WMSLayersPanel.java
+++ b/src/gov/nasa/worldwindx/examples/WMSLayersPanel.java
@@ -102,7 +102,7 @@ public class WMSLayersPanel extends JPanel
             return;
         }
 
-        // Gather up all the named layers and make a world wind layer for each.
+        // Gather up all the named layers and make a WorldWind layer for each.
         final List<WMSLayerCapabilities> namedLayerCaps = caps.getNamedLayers();
         if (namedLayerCaps == null)
             return;
@@ -224,7 +224,7 @@ public class WMSLayersPanel extends JPanel
 
         public void actionPerformed(ActionEvent actionEvent)
         {
-            // If the layer is selected, add it to the world window's current model, else remove it from the model.
+            // If the layer is selected, add it to the WorldWindow's current model, else remove it from the model.
             if (((JCheckBox) actionEvent.getSource()).isSelected())
             {
                 if (this.component == null)
@@ -238,7 +238,7 @@ public class WMSLayersPanel extends JPanel
                     updateComponent(this.component, false);
             }
 
-            // Tell the world window to update.
+            // Tell the WorldWindow to update.
             wwd.redraw();
         }
     }
@@ -284,7 +284,7 @@ public class WMSLayersPanel extends JPanel
     {
         AVList configParams = params.copy(); // Copy to insulate changes from the caller.
 
-        // Some wms servers are slow, so increase the timeouts and limits used by world wind's retrievers.
+        // Some wms servers are slow, so increase the timeouts and limits used by WorldWind's retrievers.
         configParams.setValue(AVKey.URL_CONNECT_TIMEOUT, 30000);
         configParams.setValue(AVKey.URL_READ_TIMEOUT, 30000);
         configParams.setValue(AVKey.RETRIEVAL_QUEUE_STALE_REQUEST_LIMIT, 60000);

--- a/src/gov/nasa/worldwindx/examples/WebBrowserBalloons.java
+++ b/src/gov/nasa/worldwindx/examples/WebBrowserBalloons.java
@@ -17,7 +17,7 @@ import java.awt.*;
 import java.io.InputStream;
 
 /**
- * Illustrates how to use World Wind browser balloons to display HTML, JavaScript, and Flash content to the user in the
+ * Illustrates how to use WorldWind browser balloons to display HTML, JavaScript, and Flash content to the user in the
  * form of a screen-aligned balloon. There are two browser balloon types: <code>{@link ScreenBrowserBalloon}</code>
  * which displays a balloon at a point on the screen, and <code>{@link GlobeBrowserBalloon}</code> which displays a
  * balloon attached to a position on the Globe.
@@ -49,7 +49,7 @@ public class WebBrowserBalloons extends ApplicationTemplate
             // Add a controller to handle link and navigation events in BrowserBalloons.
             this.balloonController = new BalloonController(this.getWwd());
 
-            // Size the World Window to provide enough screen space for the BrowserBalloon, and center the World Window
+            // Size the WorldWindow to provide enough screen space for the BrowserBalloon, and center the WorldWindow
             // on the screen.
             Dimension size = new Dimension(1200, 800);
             this.setPreferredSize(size);
@@ -115,6 +115,6 @@ public class WebBrowserBalloons extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_ALTITUDE, 9500000);
         Configuration.setValue(AVKey.INITIAL_PITCH, 45);
 
-        start("World Wind Web Browser Balloons", AppFrame.class);
+        start("WorldWind Web Browser Balloons", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/Wedges.java
+++ b/src/gov/nasa/worldwindx/examples/Wedges.java
@@ -207,7 +207,7 @@ public class Wedges extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Wedges", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Wedges", AppFrame.class);
     }
 }
 

--- a/src/gov/nasa/worldwindx/examples/WorldWindDiagnostics.java
+++ b/src/gov/nasa/worldwindx/examples/WorldWindDiagnostics.java
@@ -263,7 +263,7 @@ public class WorldWindDiagnostics
         if (Configuration.isMacOS())
         {
             System.setProperty("apple.laf.useScreenMenuBar", "true");
-            System.setProperty("com.apple.mrj.application.apple.menu.about.name", "World Wind Diagnostic Program");
+            System.setProperty("com.apple.mrj.application.apple.menu.about.name", "WorldWind Diagnostic Program");
             System.setProperty("com.apple.mrj.application.growbox.intrudes", "false");
         }
     }

--- a/src/gov/nasa/worldwindx/examples/analytics/AnalyticSurfaceDemo.java
+++ b/src/gov/nasa/worldwindx/examples/analytics/AnalyticSurfaceDemo.java
@@ -24,7 +24,7 @@ import java.text.*;
 import java.util.ArrayList;
 
 /**
- * Illustrates how to configure and display a 3D geographic grid of scalar data using the World Wind <code>{@link
+ * Illustrates how to configure and display a 3D geographic grid of scalar data using the WorldWind <code>{@link
  * AnalyticSurface}</code>. Analytic surface defines a grid over a geographic <code>{@link Sector}</code> at a specified
  * altitude, and enables the caller to specify the color and height at each grid point.
  * <p/>
@@ -355,6 +355,6 @@ public class AnalyticSurfaceDemo extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Analytic Surface", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Analytic Surface", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/data/BrowserBalloonExample.html
+++ b/src/gov/nasa/worldwindx/examples/data/BrowserBalloonExample.html
@@ -21,7 +21,7 @@
         <td align="left" valign="middle">
             <p><font size="+2"><strong>Web Browser Balloons</strong></font></p>
 
-            <p>Display HTML5 content on the World Wind globe using the system's native browser for Windows and
+            <p>Display HTML5 content on the WorldWind globe using the system's native browser for Windows and
                macOS.</p>
 
             <p><a href="https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/1.0_week_age_link.kml"> USGS real-time

--- a/src/gov/nasa/worldwindx/examples/data/CacheLocationConfiguration.xml
+++ b/src/gov/nasa/worldwindx/examples/data/CacheLocationConfiguration.xml
@@ -5,11 +5,11 @@
   ~ All Rights Reserved.
   -->
 
-<!-- World Wind data-file store configuration -->
+<!-- WorldWind data-file store configuration -->
 <!--$Id: CacheLocationConfiguration.xml 2851 2015-02-26 01:09:46Z tgaskins $-->
 <dataFileStore>
     <readLocations>
-        <!-- The read locations are searched, in the given order, when World Wind needs a data or image file. -->
+        <!-- The read locations are searched, in the given order, when WorldWind needs a data or image file. -->
         <!-- The write location selected from the writeLocations list is searched before these locations. -->
         <location property="gov.nasa.worldwind.platform.alluser.store" wwDir="WorldWindData"/>
         <location property="gov.nasa.worldwind.platform.user.store"    wwDir="WorldWindData"/>

--- a/src/gov/nasa/worldwindx/examples/dataimport/DataInstallUtil.java
+++ b/src/gov/nasa/worldwindx/examples/dataimport/DataInstallUtil.java
@@ -82,14 +82,14 @@ public class DataInstallUtil
     }
 
     /**
-     * Returns true if the specified input source is non-null and represents a reference to a World Wind .NET LayerSet
+     * Returns true if the specified input source is non-null and represents a reference to a WorldWind .NET LayerSet
      * XML document, and false otherwise. The input source may be one of the following: <ul> <li>{@link String}</li>
      * <li>{@link java.io.File}</li> <li>{@link java.net.URL}</li> <li>{@link java.net.URI}</li> <li>{@link
      * java.io.InputStream}</li> </ul>
      *
-     * @param source the input source reference to test as a World Wind .NET LayerSet document.
+     * @param source the input source reference to test as a WorldWind .NET LayerSet document.
      *
-     * @return true if the input source is a World Wind .NET LayerSet document, and false otherwise.
+     * @return true if the input source is a WorldWind .NET LayerSet document, and false otherwise.
      *
      * @throws IllegalArgumentException if the input source is null.
      */

--- a/src/gov/nasa/worldwindx/examples/dataimport/ImportElevations.java
+++ b/src/gov/nasa/worldwindx/examples/dataimport/ImportElevations.java
@@ -16,7 +16,7 @@ import java.awt.*;
 import java.io.File;
 
 /**
- * Illustrates how to import elevation data into World Wind. This imports a GeoTIFF file containing elevation data and
+ * Illustrates how to import elevation data into WorldWind. This imports a GeoTIFF file containing elevation data and
  * creates an <code>{@link gov.nasa.worldwind.globes.ElevationModel}</code> for it.
  *
  * @author tag
@@ -91,6 +91,6 @@ public class ImportElevations extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Elevation Import", ImportElevations.AppFrame.class);
+        ApplicationTemplate.start("WorldWind Elevation Import", ImportElevations.AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/dataimport/ImportImagery.java
+++ b/src/gov/nasa/worldwindx/examples/dataimport/ImportImagery.java
@@ -20,7 +20,7 @@ import java.awt.image.*;
 import java.io.File;
 
 /**
- * Illustrates how to import imagery into World Wind. This imports a GeoTIFF image file and displays it as a
+ * Illustrates how to import imagery into WorldWind. This imports a GeoTIFF image file and displays it as a
  * <code>{@link SurfaceImage}</code>.
  *
  * @author tag
@@ -142,6 +142,6 @@ public class ImportImagery extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Imagery Import", ImportImagery.AppFrame.class);
+        ApplicationTemplate.start("WorldWind Imagery Import", ImportImagery.AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/dataimport/InstallDTED.java
+++ b/src/gov/nasa/worldwindx/examples/dataimport/InstallDTED.java
@@ -265,6 +265,6 @@ public class InstallDTED extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind DTED Installation", InstallDTED.AppFrame.class);
+        ApplicationTemplate.start("WorldWind DTED Installation", InstallDTED.AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/dataimport/InstallElevations.java
+++ b/src/gov/nasa/worldwindx/examples/dataimport/InstallElevations.java
@@ -22,7 +22,7 @@ import java.awt.*;
 import java.io.File;
 
 /**
- * Illustrates how to install elevation data into a World Wind <code>{@link gov.nasa.worldwind.cache.FileStore}</code>.
+ * Illustrates how to install elevation data into a WorldWind <code>{@link gov.nasa.worldwind.cache.FileStore}</code>.
  * <p/>
  * Elevation data is installed into a FileStore by executing the following steps: <ol> <li>Choose the FileStore location
  * to place the installed elevations. This example uses the FileStore's install location. </li> <li>Compute a unique
@@ -149,6 +149,6 @@ public class InstallElevations extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Elevation Installation", InstallElevations.AppFrame.class);
+        ApplicationTemplate.start("WorldWind Elevation Installation", InstallElevations.AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/dataimport/InstallImagery.java
+++ b/src/gov/nasa/worldwindx/examples/dataimport/InstallImagery.java
@@ -21,7 +21,7 @@ import java.awt.*;
 import java.io.File;
 
 /**
- * Illustrates how to install imagery into a World Wind <code>{@link FileStore}</code>.
+ * Illustrates how to install imagery into a WorldWind <code>{@link FileStore}</code>.
  * <p/>
  * Image data is installed into a FileStore by executing the following steps: <ol> <li>Choose the FileStore location to
  * place the installed imagery. This example uses the default install location.</li> <li>Compute a unique cache name for
@@ -150,6 +150,6 @@ public class InstallImagery extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Imagery Installation", InstallImagery.AppFrame.class);
+        ApplicationTemplate.start("WorldWind Imagery Installation", InstallImagery.AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/dataimport/InstallImageryAndElevationsDemo.java
+++ b/src/gov/nasa/worldwindx/examples/dataimport/InstallImageryAndElevationsDemo.java
@@ -25,9 +25,9 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Illustrates a simple application that installs imagery and elevation data for use in World Wind. The application
+ * Illustrates a simple application that installs imagery and elevation data for use in WorldWind. The application
  * enables the user to locate and install imagery or elevation data on the local hard drive. Once installed, the data is
- * visualized in World Wind either as a <code>{@link gov.nasa.worldwind.layers.TiledImageLayer}</code> or an
+ * visualized in WorldWind either as a <code>{@link gov.nasa.worldwind.layers.TiledImageLayer}</code> or an
  * <code>{@link gov.nasa.worldwind.globes.ElevationModel}</code>. The application also illustrates how to visualize data
  * that has been installed during a previous session.
  * <p/>
@@ -82,7 +82,7 @@ public class InstallImageryAndElevationsDemo extends ApplicationTemplate
     {
         public static final String TOOLTIP_FULL_PYRAMID =
             "Installing a full pyramid takes longer and consumes more space on the user's hard drive, "
-                + "but has the best runtime performance, which is important for World Wind Server";
+                + "but has the best runtime performance, which is important for WorldWind Server";
 
         public static final String TOOLTIP_PARTIAL_PYRAMID =
             "Installing a partial pyramid takes less time and consumes less space on the user's hard drive"
@@ -159,7 +159,7 @@ public class InstallImageryAndElevationsDemo extends ApplicationTemplate
 
                     try
                     {
-                        // Install the file into a form usable by World Wind components.
+                        // Install the file into a form usable by WorldWind components.
                         dataConfig = installDataFromFiles(InstalledDataFrame.this, files, fileStore);
                     }
                     catch (Exception e)
@@ -300,9 +300,9 @@ public class InstallImageryAndElevationsDemo extends ApplicationTemplate
                 continue;
 
             // This data configuration came from an existing file from disk, therefore we cannot guarantee that the
-            // current version of World Wind's data installer produced it. This data configuration file may have been
-            // created by a previous version of World Wind, or by another program. Set fallback values for any missing
-            // parameters that World Wind needs to construct a Layer or ElevationModel from this data configuration.
+            // current version of WorldWind's data installer produced it. This data configuration file may have been
+            // created by a previous version of WorldWind, or by another program. Set fallback values for any missing
+            // parameters that WorldWind needs to construct a Layer or ElevationModel from this data configuration.
             AVList params = new AVListImpl();
             setFallbackParams(doc, filename, params);
 
@@ -470,7 +470,7 @@ public class InstallImageryAndElevationsDemo extends ApplicationTemplate
                 Thread.yield();
             }
 
-            // Convert the file to a form usable by World Wind components, according to the specified DataStoreProducer.
+            // Convert the file to a form usable by WorldWind components, according to the specified DataStoreProducer.
             // This throws an exception if production fails for any reason.
             producer.startProduction();
         }
@@ -696,7 +696,7 @@ public class InstallImageryAndElevationsDemo extends ApplicationTemplate
             }
             else if (DataInstallUtil.isWWDotNetLayerSet(file))
             {
-                // you cannot select multiple World Wind .NET Layer Sets
+                // you cannot select multiple WorldWind .NET Layer Sets
                 // bail out on a first raster
                 return new WWDotNetLayerSetConverter();
             }
@@ -747,6 +747,6 @@ public class InstallImageryAndElevationsDemo extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Imagery and Elevation Installation", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Imagery and Elevation Installation", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/dataimport/InstalledDataPanel.java
+++ b/src/gov/nasa/worldwindx/examples/dataimport/InstalledDataPanel.java
@@ -22,11 +22,11 @@ import java.awt.*;
 import java.awt.event.*;
 
 /**
- * Displays UI components for a set of caller specified installed data, and manages creation of World Wind components
+ * Displays UI components for a set of caller specified installed data, and manages creation of WorldWind components
  * from that data. Callers fill the panel with installed data by invoking <code>{@link
  * #addInstalledData(org.w3c.dom.Element, gov.nasa.worldwind.avlist.AVList)}</code>. This adds the UI components for a
- * specified data set (a <code>Go To</code> button, and a label description), creates a World Wind component from the
- * DataConfiguration, and adds the component to the World Window passed to the panel during construction.
+ * specified data set (a <code>Go To</code> button, and a label description), creates a WorldWind component from the
+ * DataConfiguration, and adds the component to the WorldWindow passed to the panel during construction.
  *
  * @author dcollins
  * @version $Id: InstalledDataPanel.java 1171 2013-02-11 21:45:02Z dcollins $
@@ -42,7 +42,7 @@ public class InstalledDataPanel extends JPanel
      * gov.nasa.worldwind.avlist.AVList)}.
      *
      * @param title       the panel's title, displayed in a titled border.
-     * @param worldWindow the panel's WorldWindow, which any World Wind components are added to.
+     * @param worldWindow the panel's WorldWindow, which any WorldWind components are added to.
      *
      * @throws IllegalArgumentException if the WorldWindow is null.
      */
@@ -61,10 +61,10 @@ public class InstalledDataPanel extends JPanel
     }
 
     /**
-     * Adds the UI components for the specified installed data to this panel, and adds the World Wind component created
+     * Adds the UI components for the specified installed data to this panel, and adds the WorldWind component created
      * from the data to the WorldWindow passed to this panel during construction.
      *
-     * @param domElement the document which describes a World Wind data configuration.
+     * @param domElement the document which describes a WorldWind data configuration.
      * @param params     the parameter list which overrides or extends information contained in the document.
      *
      * @throws IllegalArgumentException if the Element is null.

--- a/src/gov/nasa/worldwindx/examples/dataimport/package.html
+++ b/src/gov/nasa/worldwindx/examples/dataimport/package.html
@@ -17,23 +17,23 @@
 
 <p>
     This package contains examples that show how to import imagery and elevation data and how to use it to create
-    layers, renderables and elevation models. Since this type of data is typically in the form of a raster, World Wind
-    calls it <em>raster data</em>. World Wind can import many formats of raster data, including but not limited to JPEG,
+    layers, renderables and elevation models. Since this type of data is typically in the form of a raster, WorldWind
+    calls it <em>raster data</em>. WorldWind can import many formats of raster data, including but not limited to JPEG,
     JPEG-2000, PNG, and DTED, and GeoTIFF for both imagery and elevations. Data can be imported from a local or network
     disk, or in many cases directly from a network URL. This overview describes the import process and identifies
     example programs showing exactly how import is done.</p>
 
 <p>
-    Note that World Wind can also draw data incrementally from web services such as WMS and WFS, but this overview
+    Note that WorldWind can also draw data incrementally from web services such as WMS and WFS, but this overview
     covers only importing bulk data from files or streams.</p>
 
 <p>
-    When importing data, World Wind reprojects it to the WGS-84 datum and latitude, longitude coordinates, which is
-    World Wind's internal coordinate reference system (also known as EPSG:4326).</p>
+    When importing data, WorldWind reprojects it to the WGS-84 datum and latitude, longitude coordinates, which is
+    WorldWind's internal coordinate reference system (also known as EPSG:4326).</p>
 
 <p>
-    In addition to some internal importer classes, World Wind uses {@link javax.imageio.ImageIO} and the open-source
-    GDAL library to read and potentially reproject data on import. This enables World Wind to import a very wide range
+    In addition to some internal importer classes, WorldWind uses {@link javax.imageio.ImageIO} and the open-source
+    GDAL library to read and potentially reproject data on import. This enables WorldWind to import a very wide range
     of image formats and projection types. It also makes it possible to import very large data sets composed of many
     files.</p>
 
@@ -63,7 +63,7 @@
 
 <p>
     Installing data adds it to a permanent location on the local computer. It's installed in a way that facilitates
-    rapid access by World Wind. Unlike the World Wind cache, installed data is never automatically deleted. Applications
+    rapid access by WorldWind. Unlike the WorldWind cache, installed data is never automatically deleted. Applications
     may specify the installation location, but by default the location is:
 <ul>
     <li>Mac OS X: <em>/Library/Caches/WorldWindInstalled</em></li>
@@ -71,14 +71,14 @@
     <li>Linux, Solaris: <em>/var/cache/WorldWindInstalled</em></li>
 </ul>
 
-<p>These locations are peers to the World Wind cache directory.</p>
+<p>These locations are peers to the WorldWind cache directory.</p>
 
 <p>
     Installed imagery is typically displayed as a {@link gov.nasa.worldwind.layers.TiledImageLayer}. Elevation data is
     typically used to create an {@link gov.nasa.worldwind.globes.ElevationModel}. As these classes run, they
     automatically create sub-regions and reduced resolution versions of the data in order to optimize performance. This
     information is saved permanently in the installed-data location. Depending on the size and complexity of the data,
-    World Wind may also create one or two levels of reduced resolution data during installation.</p>
+    WorldWind may also create one or two levels of reduced resolution data during installation.</p>
 
 <p>
     When installing data, the source data can be copied to the installed-data directory or left in its original

--- a/src/gov/nasa/worldwindx/examples/elevations/RetrieveElevations.java
+++ b/src/gov/nasa/worldwindx/examples/elevations/RetrieveElevations.java
@@ -123,7 +123,7 @@ public class RetrieveElevations extends ApplicationTemplate
     public static class ElevationsDemoController implements ActionListener
     {
         protected RetrieveElevations.AppFrame frame;
-        // World Wind stuff.
+        // WorldWind stuff.
         protected WorldWindow wwd;
 
         public ElevationsDemoController(WorldWindow wwd)
@@ -227,6 +227,6 @@ public class RetrieveElevations extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        start("World Wind Get Elevations Demo", AppFrame.class);
+        start("WorldWind Get Elevations Demo", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/kml/ExportKML.java
+++ b/src/gov/nasa/worldwindx/examples/kml/ExportKML.java
@@ -17,7 +17,7 @@ import java.io.*;
 import java.util.*;
 
 /**
- * Shows how to generate KML from World Wind elements. This example creates several objects, and writes their KML
+ * Shows how to generate KML from WorldWind elements. This example creates several objects, and writes their KML
  * representation to stdout.
  *
  * @author pabercrombie

--- a/src/gov/nasa/worldwindx/examples/kml/KMLApplicationController.java
+++ b/src/gov/nasa/worldwindx/examples/kml/KMLApplicationController.java
@@ -18,7 +18,7 @@ import java.awt.*;
 import java.beans.*;
 
 /**
- * A controller that maps KML events to changes in a World Wind application. This controller animates the view to a KML
+ * A controller that maps KML events to changes in a WorldWind application. This controller animates the view to a KML
  * feature when the feature is clicked in the feature tree, and animates the view to KML network links when they are
  * refreshed.
  * <p/>

--- a/src/gov/nasa/worldwindx/examples/kml/KMLViewer.java
+++ b/src/gov/nasa/worldwindx/examples/kml/KMLViewer.java
@@ -86,7 +86,7 @@ public class KMLViewer extends ApplicationTemplate
             // KML feature balloons when feature's are selected in the on-screen layer tree.
             this.kmlAppController.setBalloonController(balloonController);
 
-            // Size the World Window to take up the space typically used by the layer panel.
+            // Size the WorldWindow to take up the space typically used by the layer panel.
             Dimension size = new Dimension(1400, 800);
             this.setPreferredSize(size);
             this.pack();
@@ -117,7 +117,7 @@ public class KMLViewer extends ApplicationTemplate
          */
         protected void addKMLLayer(KMLRoot kmlRoot)
         {
-            // Create a KMLController to adapt the KMLRoot to the World Wind renderable interface.
+            // Create a KMLController to adapt the KMLRoot to the WorldWind renderable interface.
             KMLController kmlController = new KMLController(kmlRoot);
 
             // Adds a new layer containing the KMLRoot to the end of the WorldWindow's layer list. This
@@ -312,6 +312,6 @@ public class KMLViewer extends ApplicationTemplate
     public static void main(String[] args)
     {
         //noinspection UnusedDeclaration
-        final AppFrame af = (AppFrame) start("World Wind KML Viewer", AppFrame.class);
+        final AppFrame af = (AppFrame) start("WorldWind KML Viewer", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/layermanager/LayerManagerApp.java
+++ b/src/gov/nasa/worldwindx/examples/layermanager/LayerManagerApp.java
@@ -92,7 +92,7 @@ public class LayerManagerApp
         if (Configuration.isMacOS())
         {
             System.setProperty("apple.laf.useScreenMenuBar", "true");
-            System.setProperty("com.apple.mrj.application.apple.menu.about.name", "World Wind Application");
+            System.setProperty("com.apple.mrj.application.apple.menu.about.name", "WorldWind Application");
             System.setProperty("com.apple.mrj.application.growbox.intrudes", "false");
         }
         else if (Configuration.isWindowsOS())

--- a/src/gov/nasa/worldwindx/examples/layermanager/LayerManagerPanel.java
+++ b/src/gov/nasa/worldwindx/examples/layermanager/LayerManagerPanel.java
@@ -109,7 +109,7 @@ public class LayerManagerPanel extends JPanel
         this.layerPanels.clear();
         this.layerNamesPanel.removeAll();
 
-        // Fill the layers panel with the titles of all layers in the world window's current model.
+        // Fill the layers panel with the titles of all layers in the WorldWindow's current model.
         for (Layer layer : wwd.getModel().getLayers())
         {
             if (layer.getValue(AVKey.IGNORE) != null)
@@ -146,7 +146,7 @@ public class LayerManagerPanel extends JPanel
      * Loops through this layer panel's layer/checkbox list and updates the checkbox font to indicate whether the
      * corresponding layer was just rendered. This method is called by a rendering listener -- see comment below.
      *
-     * @param wwd the world window.
+     * @param wwd the WorldWindow.
      */
     protected void updateLayerActivity(WorldWindow wwd)
     {

--- a/src/gov/nasa/worldwindx/examples/lineofsight/AbstractShapeIntersection.java
+++ b/src/gov/nasa/worldwindx/examples/lineofsight/AbstractShapeIntersection.java
@@ -154,6 +154,6 @@ public class AbstractShapeIntersection extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_HEADING, 27);
         Configuration.setValue(AVKey.INITIAL_PITCH, 30);
 
-        ApplicationTemplate.start("World Wind Extruded Abstract Shape Intersection", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Extruded Abstract Shape Intersection", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/lineofsight/ExtrudedPolygonIntersection.java
+++ b/src/gov/nasa/worldwindx/examples/lineofsight/ExtrudedPolygonIntersection.java
@@ -156,6 +156,6 @@ public class ExtrudedPolygonIntersection extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_HEADING, 27);
         Configuration.setValue(AVKey.INITIAL_PITCH, 30);
 
-        ApplicationTemplate.start("World Wind Extruded Polygon Intersection", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Extruded Polygon Intersection", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/lineofsight/GridOfPoints.java
+++ b/src/gov/nasa/worldwindx/examples/lineofsight/GridOfPoints.java
@@ -188,6 +188,6 @@ public class GridOfPoints extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_HEADING, 27);
         Configuration.setValue(AVKey.INITIAL_PITCH, 30);
 
-        ApplicationTemplate.start("World Wind Point Grid", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Point Grid", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/lineofsight/LinesOfSight.java
+++ b/src/gov/nasa/worldwindx/examples/lineofsight/LinesOfSight.java
@@ -344,7 +344,7 @@ public class LinesOfSight extends ApplicationTemplate
 
             final int progress = (int) (100d * numPositionsProcessed / (double) totalNum);
 
-            // On the EDT, update the progress bar and if calculations are complete, update the World Window.
+            // On the EDT, update the progress bar and if calculations are complete, update the WorldWindow.
             SwingUtilities.invokeLater(new Runnable()
             {
                 public void run()
@@ -365,7 +365,7 @@ public class LinesOfSight extends ApplicationTemplate
             });
         }
 
-        /** Updates the World Wind model with the new intersection locations and sight lines. */
+        /** Updates the WorldWind model with the new intersection locations and sight lines. */
         protected void showResults()
         {
             this.intersectionsLayer.removeAllRenderables();
@@ -612,6 +612,6 @@ public class LinesOfSight extends ApplicationTemplate
     public static void main(String[] args)
     {
         // Adjust configuration values before instantiation
-        ApplicationTemplate.start("World Wind Terrain Intersections", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Terrain Intersections", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/lineofsight/PolygonIntersection.java
+++ b/src/gov/nasa/worldwindx/examples/lineofsight/PolygonIntersection.java
@@ -145,6 +145,6 @@ public class PolygonIntersection extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_HEADING, 27);
         Configuration.setValue(AVKey.INITIAL_PITCH, 30);
 
-        ApplicationTemplate.start("World Wind Polygon Intersection", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Polygon Intersection", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/multiwindow/CardLayoutUsage.java
+++ b/src/gov/nasa/worldwindx/examples/multiwindow/CardLayoutUsage.java
@@ -20,31 +20,31 @@ import java.awt.*;
 import java.awt.event.*;
 
 /**
- * This class illustrates how to use multiple World Wind windows with a {@link CardLayout} layer manager.
+ * This class illustrates how to use multiple WorldWind windows with a {@link CardLayout} layer manager.
  * <p/>
- * Applications using multiple World Wind windows simultaneously should instruct World Wind to share OpenGL and other
- * resources among those windows. Most World Wind classes are designed to be shared across {@link WorldWindow} objects
+ * Applications using multiple WorldWind windows simultaneously should instruct WorldWind to share OpenGL and other
+ * resources among those windows. Most WorldWind classes are designed to be shared across {@link WorldWindow} objects
  * and will be shared automatically. But OpenGL resources are not automatically shared. To share them, a reference to a
  * previously created WorldWindow must be specified as a constructor argument for subsequently created WorldWindows.
  * <p/>
- * Most World Wind {@link Globe} and {@link Layer} objects can be shared among WorldWindows. Those that cannot be shared
+ * Most WorldWind {@link Globe} and {@link Layer} objects can be shared among WorldWindows. Those that cannot be shared
  * have an operational dependency on the WorldWindow they're associated with. An example is the {@link
  * ViewControlsLayer} layer for on-screen navigation. Because this layer responds to input events within a specific
- * WorldWindow, it is not sharable. Refer to the World Wind Overview page for a list of layers that cannot be shared.
+ * WorldWindow, it is not sharable. Refer to the WorldWind Overview page for a list of layers that cannot be shared.
  * // TODO: include the reference to overview.html.
  *
  * @version $Id: CardLayoutUsage.java 1853 2014-02-28 19:28:23Z tgaskins $
  */
 public class CardLayoutUsage extends JFrame
 {
-    private static class WWPanel extends JPanel // A class to encapsulate a World Window that shares resources.
+    private static class WWPanel extends JPanel // A class to encapsulate a WorldWindow that shares resources.
     {
         WorldWindowGLCanvas wwd;
 
         public WWPanel(WorldWindowGLCanvas shareWith, int width, int height)
         {
-            // To share resources among World Windows, pass the first World Window to the constructor of the other
-            // World Windows.
+            // To share resources among WorldWindows, pass the first WorldWindow to the constructor of the other
+            // WorldWindows.
             this.wwd = shareWith != null ? new WorldWindowGLCanvas(shareWith) : new WorldWindowGLCanvas();
             this.wwd.setSize(new java.awt.Dimension(width, height));
 
@@ -69,16 +69,16 @@ public class CardLayoutUsage extends JFrame
             JPanel cardPanel = new JPanel();
             cardPanel.setLayout(new CardLayout());
 
-            // Create the first World Window and add it to the card panel.
+            // Create the first WorldWindow and add it to the card panel.
             this.wwpA = new WWPanel(null, 600, 600);
 
-            // Add the first World Window to the card panel.
-            cardPanel.add(wwpA, "World Window A");
+            // Add the first WorldWindow to the card panel.
+            cardPanel.add(wwpA, "WorldWindow A");
 
             // Create the Model, starting with the Globe.
             Globe earth = new Earth();
 
-            // Create layers that both World Windows can share.
+            // Create layers that both WorldWindows can share.
             Layer[] layers = new Layer[]
                 {
                     new StarsLayer(),
@@ -97,7 +97,7 @@ public class CardLayoutUsage extends JFrame
             modelForWindowB.setGlobe(earth);
             modelForWindowB.setLayers(new LayerList(layers));
 
-            // Add view control layers, which the World Windows cannot share.
+            // Add view control layers, which the WorldWindows cannot share.
             ViewControlsLayer viewControlsA = new ViewControlsLayer();
             wwpA.wwd.getModel().getLayers().add(viewControlsA);
             wwpA.wwd.addSelectListener(new ViewControlsSelectListener(wwpA.wwd, viewControlsA));
@@ -108,18 +108,18 @@ public class CardLayoutUsage extends JFrame
             this.add(cardPanel, BorderLayout.CENTER);
             this.add(this.makeControlPanel((CardLayout) cardPanel.getLayout(), cardPanel), BorderLayout.SOUTH);
 
-            // Position and display the frame. It's essential to do this before creating the second World Window. This
+            // Position and display the frame. It's essential to do this before creating the second WorldWindow. This
             // first one must be visible in order for the second one to share its OpenGL resources.
-            this.setTitle("World Wind Multi-Window CardLayout");
+            this.setTitle("WorldWind Multi-Window CardLayout");
             this.setDefaultCloseOperation(javax.swing.JFrame.EXIT_ON_CLOSE);
             this.pack();
             WWUtil.alignComponent(null, this, AVKey.CENTER); // Center the application on the screen.
             this.setResizable(true);
             this.setVisible(true);
 
-            // Now that the first World Window is visible, create the second one.
+            // Now that the first WorldWindow is visible, create the second one.
             this.wwpB = new WWPanel(wwpA.wwd, wwpA.getWidth(), wwpA.getHeight());
-            cardPanel.add(wwpB, "World Window B");
+            cardPanel.add(wwpB, "WorldWindow B");
             wwpB.wwd.setModel(modelForWindowB);
             wwpB.wwd.getModel().getLayers().add(viewControlsB);
             wwpB.wwd.addSelectListener(new ViewControlsSelectListener(wwpB.wwd, viewControlsB));
@@ -135,14 +135,14 @@ public class CardLayoutUsage extends JFrame
 
     private JPanel makeControlPanel(final CardLayout cardLayout, final JPanel cardLayoutParent)
     {
-        final JButton buttonA = new JButton("World Window A");
-        final JButton buttonB = new JButton(" World Window B");
+        final JButton buttonA = new JButton("WorldWindow A");
+        final JButton buttonB = new JButton(" WorldWindow B");
 
         buttonA.addActionListener(new ActionListener()
         {
             public void actionPerformed(ActionEvent actionEvent)
             {
-                cardLayout.show(cardLayoutParent, "World Window A");
+                cardLayout.show(cardLayoutParent, "WorldWindow A");
                 buttonA.setEnabled(false);
                 buttonB.setEnabled(true);
                 wwpA.wwd.redraw();
@@ -153,7 +153,7 @@ public class CardLayoutUsage extends JFrame
         {
             public void actionPerformed(ActionEvent actionEvent)
             {
-                cardLayout.show(cardLayoutParent, "World Window B");
+                cardLayout.show(cardLayoutParent, "WorldWindow B");
                 buttonA.setEnabled(true);
                 buttonB.setEnabled(false);
                 wwpB.wwd.redraw();

--- a/src/gov/nasa/worldwindx/examples/multiwindow/FlatAndRoundGlobes.java
+++ b/src/gov/nasa/worldwindx/examples/multiwindow/FlatAndRoundGlobes.java
@@ -27,15 +27,15 @@ import java.util.ArrayList;
 /**
  * This class illustrates how to display round and flat globes side by side.
  * <p/>
- * Applications using multiple World Wind windows simultaneously should instruct World Wind to share OpenGL and other
- * resources among those windows. Most World Wind classes are designed to be shared across {@link WorldWindow} objects
+ * Applications using multiple WorldWind windows simultaneously should instruct WorldWind to share OpenGL and other
+ * resources among those windows. Most WorldWind classes are designed to be shared across {@link WorldWindow} objects
  * and will be shared automatically. But OpenGL resources are not automatically shared. To share them, a reference to a
  * previously created WorldWindow must be specified as a constructor argument for subsequently created WorldWindows.
  * <p/>
- * Most World Wind {@link Globe} and {@link Layer} objects can be shared among WorldWindows. Those that cannot be shared
+ * Most WorldWind {@link Globe} and {@link Layer} objects can be shared among WorldWindows. Those that cannot be shared
  * have an operational dependency on the WorldWindow they're associated with. An example is the {@link
  * ViewControlsLayer} layer for on-screen navigation. Because this layer responds to input events within a specific
- * WorldWindow, it is not sharable. Refer to the World Wind Overview page for a list of layers that cannot be shared.
+ * WorldWindow, it is not sharable. Refer to the WorldWind Overview page for a list of layers that cannot be shared.
  *
  * @author tag
  * @version $Id: FlatAndRoundGlobes.java 2219 2014-08-11 21:39:44Z dcollins $
@@ -332,7 +332,7 @@ public class FlatAndRoundGlobes
 
     public static void main(String[] args)
     {
-        String appName = "World Wind MultiGlobe";
+        String appName = "WorldWind MultiGlobe";
 
         if (Configuration.isMacOS())
             System.setProperty("com.apple.mrj.application.apple.menu.about.name", appName);

--- a/src/gov/nasa/worldwindx/examples/multiwindow/MultiFrame.java
+++ b/src/gov/nasa/worldwindx/examples/multiwindow/MultiFrame.java
@@ -17,19 +17,19 @@ import javax.swing.*;
 import java.awt.*;
 
 /**
- * This example shows how to create two World Windows, each in its own JFrame. The World Windows share a globe and some
+ * This example shows how to create two WorldWindows, each in its own JFrame. The WorldWindows share a globe and some
  * layers.
  * <p/>
- * Applications using multiple World Wind windows simultaneously should instruct World Wind to share OpenGL and other
- * resources among those windows. Most World Wind classes are designed to be shared across {@link WorldWindow} objects
+ * Applications using multiple WorldWind windows simultaneously should instruct WorldWind to share OpenGL and other
+ * resources among those windows. Most WorldWind classes are designed to be shared across {@link WorldWindow} objects
  * and are shared automatically. But OpenGL resources are not automatically shared. To share them, a reference to a
  * previously created WorldWindow must be specified as a constructor argument for subsequently created WorldWindows.
  * <p/>
- * Most World Wind {@link gov.nasa.worldwind.globes.Globe} and {@link gov.nasa.worldwind.layers.Layer} objects can be
- * shared among World Windows. Those that cannot be shared have an operational dependency on the World Window they're
+ * Most WorldWind {@link gov.nasa.worldwind.globes.Globe} and {@link gov.nasa.worldwind.layers.Layer} objects can be
+ * shared among WorldWindows. Those that cannot be shared have an operational dependency on the WorldWindow they're
  * associated with. An example is the {@link gov.nasa.worldwind.layers.ViewControlsLayer} layer for on-screen
- * navigation. Because this layer responds to input events within a specific World Window, it is not sharable. Refer to
- * the World Wind Overview page for a list of layers that cannot be shared.
+ * navigation. Because this layer responds to input events within a specific WorldWindow, it is not sharable. Refer to
+ * the WorldWind Overview page for a list of layers that cannot be shared.
  * // TODO: include the reference to overview.html.
  *
  * @author tag
@@ -37,15 +37,15 @@ import java.awt.*;
  */
 public class MultiFrame
 {
-    // A panel to hold a World Window and status bar.
+    // A panel to hold a WorldWindow and status bar.
     private static class WWPanel extends JPanel
     {
         private WorldWindowGLCanvas wwd;
 
         public WWPanel(WorldWindowGLCanvas shareWith, int width, int height, Model model)
         {
-            // To share resources among World Windows, pass the first World Window to the constructor of the other
-            // World Windows.
+            // To share resources among WorldWindows, pass the first WorldWindow to the constructor of the other
+            // WorldWindows.
             this.wwd = shareWith != null ? new WorldWindowGLCanvas(shareWith) : new WorldWindowGLCanvas();
             this.wwd.setSize(new java.awt.Dimension(width, height));
             this.wwd.setModel(model);
@@ -59,7 +59,7 @@ public class MultiFrame
         }
     }
 
-    // A JFrame to hold one World Window panel. Multiple of these are created in main below.
+    // A JFrame to hold one WorldWindow panel. Multiple of these are created in main below.
     private static class CanvasFrame extends javax.swing.JFrame
     {
         private WWPanel wwp;
@@ -95,7 +95,7 @@ public class MultiFrame
             // Create a Model for each window, starting with the Globe they share.
             Globe earth = new Earth();
 
-            // Create layers that both World Windows can share.
+            // Create layers that both WorldWindows can share.
             Layer[] layers = new Layer[]
                 {
                     new StarsLayer(),
@@ -127,7 +127,7 @@ public class MultiFrame
             frameB.wwp.wwd.setModel(modelForWindowB);
             frameB.setVisible(true);
 
-            // Add view control layers, which the World Windows cannnot share.
+            // Add view control layers, which the WorldWindows cannnot share.
             ViewControlsLayer viewControlsA = new ViewControlsLayer();
             frameA.wwp.wwd.getModel().getLayers().add(viewControlsA);
             frameA.wwp.wwd.addSelectListener(new ViewControlsSelectListener(frameA.wwp.wwd, viewControlsA));

--- a/src/gov/nasa/worldwindx/examples/multiwindow/SharedShapes.java
+++ b/src/gov/nasa/worldwindx/examples/multiwindow/SharedShapes.java
@@ -26,20 +26,20 @@ import java.awt.event.*;
 import java.util.Arrays;
 
 /**
- * This example shows how to share World Wind shapes between two {@link WorldWindow} instances. In this example the two
- * World Wind windows share imagery layers and the layers representing each type of shape. Though this example uses a
+ * This example shows how to share WorldWind shapes between two {@link WorldWindow} instances. In this example the two
+ * WorldWind windows share imagery layers and the layers representing each type of shape. Though this example uses a
  * different globe for each window, it is possible for the two windows to share the same {@link Globe} as is done in the
  * {@link MultiFrame} example.
  * <p/>
- * Applications using multiple World Wind windows simultaneously should instruct World Wind to share OpenGL and other
- * resources among those windows. Most World Wind classes are designed to be shared across WorldWindow objects and are
+ * Applications using multiple WorldWind windows simultaneously should instruct WorldWind to share OpenGL and other
+ * resources among those windows. Most WorldWind classes are designed to be shared across WorldWindow objects and are
  * shared automatically. But OpenGL resources are not automatically shared. To share them, a reference to a previously
  * created WorldWindow must be specified as a constructor argument for subsequently created WorldWindows.
  * <p/>
- * Most World Wind Globe and {@link gov.nasa.worldwind.layers.Layer} objects can be shared among World Windows. Those
- * that cannot be shared have an operational dependency on the World Window they're associated with. An example is the
+ * Most WorldWind Globe and {@link gov.nasa.worldwind.layers.Layer} objects can be shared among WorldWindows. Those
+ * that cannot be shared have an operational dependency on the WorldWindow they're associated with. An example is the
  * {@link gov.nasa.worldwind.layers.ViewControlsLayer} layer for on-screen navigation. Because this layer responds to
- * input events within a specific World Window, it is not sharable. Refer to the World Wind Overview page for a list of
+ * input events within a specific WorldWindow, it is not sharable. Refer to the WorldWind Overview page for a list of
  * layers that cannot be shared.
  *
  * @author dcollins
@@ -233,39 +233,39 @@ public class SharedShapes
                 makeAirspaceLayer()
             };
 
-        // Create the shared World Wind layers.
+        // Create the shared WorldWind layers.
         Layer[] layers = new Layer[basicLayers.length + shapeLayers.length];
         System.arraycopy(basicLayers, 0, layers, 0, basicLayers.length);
         System.arraycopy(shapeLayers, 0, layers, basicLayers.length, shapeLayers.length);
 
-        // Create separate models for each World Window.
+        // Create separate models for each WorldWindow.
         Model modelForWindowA = new BasicModel(new Earth(), new LayerList(layers));
         Model modelForWindowB = new BasicModel(new EarthFlat(), new LayerList(layers));
 
-        // Create the first World Window.
+        // Create the first WorldWindow.
         WWPanel panelA = new WWPanel(null, modelForWindowA, new Dimension(900, 900));
 
         // Create a layer panel that displays the layer list shared by both WorldWindows.
         SharedLayerPanel layerPanel = new SharedLayerPanel("Shared Shapes", new Dimension(200, 0),
             Arrays.asList(shapeLayers));
 
-        // Create a box that arranges the layer panel and the World Wind windows horizontally, and assigns each the
+        // Create a box that arranges the layer panel and the WorldWind windows horizontally, and assigns each the
         // appropriate amount of space for its preferred size.
         javax.swing.Box box = javax.swing.Box.createHorizontalBox();
         box.add(layerPanel);
         box.add(javax.swing.Box.createHorizontalStrut(5));
         box.add(panelA);
 
-        // Create an application frame to display the two World Wind windows and the shared layer panel.
-        JFrame appFrame = new JFrame("World Wind Shared Shapes");
+        // Create an application frame to display the two WorldWind windows and the shared layer panel.
+        JFrame appFrame = new JFrame("WorldWind Shared Shapes");
         appFrame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
         appFrame.getContentPane().add(box, BorderLayout.CENTER);
 
-        // Make the first World Window visible. This is essential in order to share OpenGL resources with the second
-        // World Window created below.
+        // Make the first WorldWindow visible. This is essential in order to share OpenGL resources with the second
+        // WorldWindow created below.
         appFrame.setVisible(true);
 
-        // Make the second World Window and tell it to share OpenGL resources with the first World Window.
+        // Make the second WorldWindow and tell it to share OpenGL resources with the first WorldWindow.
         WWPanel panelB = new WWPanel(panelA.getWwd(), modelForWindowB, new Dimension(900, 900));
         box.add(javax.swing.Box.createHorizontalStrut(5));
         box.add(panelB);

--- a/src/gov/nasa/worldwindx/examples/multiwindow/TabbedPaneUsage.java
+++ b/src/gov/nasa/worldwindx/examples/multiwindow/TabbedPaneUsage.java
@@ -18,17 +18,17 @@ import javax.swing.*;
 import java.awt.*;
 
 /**
- * This class illustrates how to use multiple World Wind windows with a {@link JTabbedPane}.
+ * This class illustrates how to use multiple WorldWind windows with a {@link JTabbedPane}.
  * <p/>
- * Applications using multiple World Wind windows simultaneously should instruct World Wind to share OpenGL and other
- * resources among those windows. Most World Wind classes are designed to be shared across {@link WorldWindow} objects
+ * Applications using multiple WorldWind windows simultaneously should instruct WorldWind to share OpenGL and other
+ * resources among those windows. Most WorldWind classes are designed to be shared across {@link WorldWindow} objects
  * and will be shared automatically. But OpenGL resources are not automatically shared. To share them, a reference to a
  * previously created WorldWindow must be specified as a constructor argument for subsequently created WorldWindows.
  * <p/>
- * Most World Wind {@link gov.nasa.worldwind.globes.Globe} and {@link gov.nasa.worldwind.layers.Layer} objects can be shared among WorldWindows. Those that cannot be shared
+ * Most WorldWind {@link gov.nasa.worldwind.globes.Globe} and {@link gov.nasa.worldwind.layers.Layer} objects can be shared among WorldWindows. Those that cannot be shared
  * have an operational dependency on the WorldWindow they're associated with. An example is the {@link
  * gov.nasa.worldwind.layers.ViewControlsLayer} layer for on-screen navigation. Because this layer responds to input events within a specific
- * WorldWindow, it is not sharable. Refer to the World Wind Overview page for a list of layers that cannot be shared.
+ * WorldWindow, it is not sharable. Refer to the WorldWind Overview page for a list of layers that cannot be shared.
  * // TODO: include the reference to overview.html.
  *
  * @version $Id: TabbedPaneUsage.java 1853 2014-02-28 19:28:23Z tgaskins $
@@ -41,8 +41,8 @@ public class TabbedPaneUsage extends JFrame
 
         public WWPanel(WorldWindowGLCanvas shareWith, int width, int height)
         {
-            // To share resources among World Windows, pass the first World Window to the constructor of the other
-            // World Windows.
+            // To share resources among WorldWindows, pass the first WorldWindow to the constructor of the other
+            // WorldWindows.
             this.wwd = shareWith != null ? new WorldWindowGLCanvas(shareWith) : new WorldWindowGLCanvas();
             this.wwd.setSize(new java.awt.Dimension(width, height));
 
@@ -64,14 +64,14 @@ public class TabbedPaneUsage extends JFrame
             JTabbedPane tabbedPanel = new JTabbedPane();
             this.add(tabbedPanel, BorderLayout.CENTER);
 
-            // Create the first World Window and add it to the tabbed panel.
+            // Create the first WorldWindow and add it to the tabbed panel.
             WWPanel wwpA = new WWPanel(null, 600, 600);
-            tabbedPanel.add(wwpA, "World Window A");
+            tabbedPanel.add(wwpA, "WorldWindow A");
 
             // Create the Model, starting with the Globe.
             Globe earth = new Earth();
 
-            // Create layers that both World Windows can share.
+            // Create layers that both WorldWindows can share.
             Layer[] layers = new Layer[]
                 {
                     new StarsLayer(),
@@ -90,7 +90,7 @@ public class TabbedPaneUsage extends JFrame
             modelForWindowB.setGlobe(new Earth());
             modelForWindowB.setLayers(new LayerList(layers));
 
-            // Add view control layers, which the World Windows cannot share.
+            // Add view control layers, which the WorldWindows cannot share.
             ViewControlsLayer viewControlsA = new ViewControlsLayer();
             wwpA.wwd.getModel().getLayers().add(viewControlsA);
             wwpA.wwd.addSelectListener(new ViewControlsSelectListener(wwpA.wwd, viewControlsA));
@@ -100,18 +100,18 @@ public class TabbedPaneUsage extends JFrame
             // Add the tabbed panel to the frame.
             this.add(tabbedPanel, BorderLayout.CENTER);
 
-            // Position and display the frame. It's essential to do this before creating the second World Window. This
+            // Position and display the frame. It's essential to do this before creating the second WorldWindow. This
             // first one must be visible in order for the second one to share its OpenGL resources.
-            this.setTitle("World Wind Multi-Window Tabbed Pane");
+            this.setTitle("WorldWind Multi-Window Tabbed Pane");
             this.setDefaultCloseOperation(javax.swing.JFrame.EXIT_ON_CLOSE);
             this.pack();
             WWUtil.alignComponent(null, this, AVKey.CENTER); // Center the application on the screen.
             this.setResizable(true);
             this.setVisible(true);
 
-            // Now that the first World Window is visible, create the second one.
+            // Now that the first WorldWindow is visible, create the second one.
             WWPanel wwpB = new WWPanel(wwpA.wwd, wwpA.getWidth(), wwpA.getHeight());
-            tabbedPanel.add(wwpB, "World Window B");
+            tabbedPanel.add(wwpB, "WorldWindow B");
             wwpB.wwd.setModel(modelForWindowB);
             wwpB.wwd.getModel().getLayers().add(viewControlsB);
             wwpB.wwd.addSelectListener(new ViewControlsSelectListener(wwpB.wwd, viewControlsB));

--- a/src/gov/nasa/worldwindx/examples/multiwindow/ViewViewVolume.java
+++ b/src/gov/nasa/worldwindx/examples/multiwindow/ViewViewVolume.java
@@ -18,16 +18,16 @@ import java.awt.*;
  * This class illustrates how to display a globe, and in a separate window display another globe with a visualization of
  * the view volume in the main globe window.
  * <p/>
- * Applications using multiple World Wind windows simultaneously should instruct World Wind to share OpenGL and other
- * resources among those windows. Most World Wind classes are designed to be shared across {@link WorldWindow} objects
+ * Applications using multiple WorldWind windows simultaneously should instruct WorldWind to share OpenGL and other
+ * resources among those windows. Most WorldWind classes are designed to be shared across {@link WorldWindow} objects
  * and will be shared automatically. But OpenGL resources are not automatically shared. To share them, a reference to a
  * previously created WorldWindow must be specified as a constructor argument for subsequently created WorldWindows.
  * <p/>
- * Most World Wind {@link gov.nasa.worldwind.globes.Globe} and {@link gov.nasa.worldwind.layers.Layer} objects can be
+ * Most WorldWind {@link gov.nasa.worldwind.globes.Globe} and {@link gov.nasa.worldwind.layers.Layer} objects can be
  * shared among WorldWindows. Those that cannot be shared have an operational dependency on the WorldWindow they're
  * associated with. An example is the {@link gov.nasa.worldwind.layers.ViewControlsLayer} layer for on-screen
  * navigation. Because this layer responds to input events within a specific WorldWindow, it is not sharable. Refer to
- * the World Wind Overview page for a list of layers that cannot be shared.
+ * the WorldWind Overview page for a list of layers that cannot be shared.
  *
  * @author tag
  * @version $Id: ViewViewVolume.java 1171 2013-02-11 21:45:02Z dcollins $
@@ -39,7 +39,7 @@ public class ViewViewVolume extends JFrame
         if (gov.nasa.worldwind.Configuration.isMacOS())
         {
             System.setProperty("apple.laf.useScreenMenuBar", "true");
-            System.setProperty("com.apple.mrj.application.apple.menu.about.name", "World Wind Multi-Window Analysis");
+            System.setProperty("com.apple.mrj.application.apple.menu.about.name", "WorldWind Multi-Window Analysis");
             System.setProperty("com.apple.mrj.application.growbox.intrudes", "false");
         }
     }
@@ -87,7 +87,7 @@ public class ViewViewVolume extends JFrame
         {
             public void run()
             {
-                // Make a World Window to observe
+                // Make a WorldWindow to observe
                 ViewViewVolume vvv = new ViewViewVolume();
                 vvv.setVisible(true);
 

--- a/src/gov/nasa/worldwindx/examples/multiwindow/package.html
+++ b/src/gov/nasa/worldwindx/examples/multiwindow/package.html
@@ -16,17 +16,17 @@
 
 <p>Examples of how to use multiple WorldWind globes in the same application.</p>
 
-<p>Applications using multiple World Wind windows simultaneously should instruct World Wind to share OpenGL and other
-   resources among those windows. Most World Wind classes are designed to be shared across {@link
+<p>Applications using multiple WorldWind windows simultaneously should instruct WorldWind to share OpenGL and other
+   resources among those windows. Most WorldWind classes are designed to be shared across {@link
    gov.nasa.worldwind.WorldWindow} objects and will be shared automatically. But OpenGL resources are not automatically
    shared. To share them, a reference to a previously created WorldWindow must be specified as a constructor argument
    for subsequently created WorldWindows.</p>
 
-<p>Most World Wind {@link gov.nasa.worldwind.globes.Globe} and {@link gov.nasa.worldwind.layers.Layer} objects can be
+<p>Most WorldWind {@link gov.nasa.worldwind.globes.Globe} and {@link gov.nasa.worldwind.layers.Layer} objects can be
    shared among WorldWindows. Those that cannot be shared have an operational dependency on the WorldWindow they're
    associated with. An example is the {@link gov.nasa.worldwind.layers.ViewControlsLayer} layer for on-screen
    navigation. Because this layer responds to input events within a specific WorldWindow, it is not sharable. Refer to
-   the World Wind Overview page for a list of layers that cannot be shared.</p>
+   the WorldWind Overview page for a list of layers that cannot be shared.</p>
 
 </body>
 </html>

--- a/src/gov/nasa/worldwindx/examples/shapebuilder/AbstractShapeEditor.java
+++ b/src/gov/nasa/worldwindx/examples/shapebuilder/AbstractShapeEditor.java
@@ -33,7 +33,7 @@ public abstract class AbstractShapeEditor extends AbstractLayer implements Mouse
 {
     /**
      * Labels used in the annotations which are displayed during editing to show the current value of various shape
-     * parameters.  Actual label values are retrieved from the World Wind message resource bundle.
+     * parameters.  Actual label values are retrieved from the WorldWind message resource bundle.
      */
     public static final String ANGLE_LABEL = "MeasureTool.AngleLabel";
     public static final String AREA_LABEL = "MeasureTool.AreaLabel";

--- a/src/gov/nasa/worldwindx/examples/symbology/DeclutterTacticalSymbols.java
+++ b/src/gov/nasa/worldwindx/examples/symbology/DeclutterTacticalSymbols.java
@@ -143,10 +143,10 @@ public class DeclutterTacticalSymbols extends ApplicationTemplate
             machineGunSymbol.setLODSelector(lodSelector); // specify the LOD selector
             this.symbolLayer.addRenderable(machineGunSymbol);
 
-            // Add the symbol layer to the World Wind model.
+            // Add the symbol layer to the WorldWind model.
             this.getWwd().getModel().getLayers().add(symbolLayer);
 
-            // Size the World Window to provide enough screen space for the symbols and center the World Window on the
+            // Size the WorldWindow to provide enough screen space for the symbols and center the WorldWindow on the
             // screen.
             Dimension size = new Dimension(1800, 1000);
             this.setPreferredSize(size);
@@ -164,6 +164,6 @@ public class DeclutterTacticalSymbols extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_PITCH, 82);
         Configuration.setValue(AVKey.INITIAL_ALTITUDE, 20000);
 
-        start("World Wind Tactical Symbol Decluttering", AppFrame.class);
+        start("WorldWind Tactical Symbol Decluttering", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/symbology/IconRetrieverUsage.java
+++ b/src/gov/nasa/worldwindx/examples/symbology/IconRetrieverUsage.java
@@ -96,7 +96,7 @@ public class IconRetrieverUsage
     {
         if (Configuration.isMacOS())
         {
-            System.setProperty("com.apple.mrj.application.apple.menu.about.name", "World Wind Icon Retriever");
+            System.setProperty("com.apple.mrj.application.apple.menu.about.name", "WorldWind Icon Retriever");
         }
 
         SwingUtilities.invokeLater(new Runnable()
@@ -106,7 +106,7 @@ public class IconRetrieverUsage
                 // Create an AppFrame and immediately make it visible. As per Swing convention, this
                 // is done within an invokeLater call so that it executes on an AWT thread.
                 JFrame appFrame = new AppFrame();
-                appFrame.setTitle("World Wind Icon Retriever");
+                appFrame.setTitle("WorldWind Icon Retriever");
                 appFrame.setVisible(true);
                 appFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
             }

--- a/src/gov/nasa/worldwindx/examples/symbology/Symbology.java
+++ b/src/gov/nasa/worldwindx/examples/symbology/Symbology.java
@@ -21,10 +21,10 @@ import java.util.*;
 import java.util.List;
 
 /**
- * Demonstrates the simplest possible usage of World Wind {@link TacticalSymbol} and {@link
+ * Demonstrates the simplest possible usage of WorldWind {@link TacticalSymbol} and {@link
  * gov.nasa.worldwind.symbology.TacticalGraphic} to display symbols from the MIL-STD-2525 symbology set. See the <a
  * title="Symbology Usage Guide" href="https://goworldwind.org/developers-guide/symbology/" target="_blank">Symbology
- * Usage Guide</a> for more information on symbology support in World Wind.
+ * Usage Guide</a> for more information on symbology support in WorldWind.
  * <p/>
  * For more detailed examples of how to use TacticalSymbol and TacticalGraphic in an application, see the {@link
  * TacticalSymbols} example and the {@link TacticalGraphics} example.
@@ -40,13 +40,13 @@ public class Symbology extends ApplicationTemplate
         {
             super(true, true, false);
 
-            // Create a layer that displays World Wind tactical symbols.
+            // Create a layer that displays WorldWind tactical symbols.
             this.addTacticalSymbols();
 
-            // Create a layer that displays World Wind tactical graphics.
+            // Create a layer that displays WorldWind tactical graphics.
             this.addTacticalGraphics();
 
-            // Size the World Window to provide enough screen space for the graphics, and center the World Window
+            // Size the WorldWindow to provide enough screen space for the graphics, and center the WorldWindow
             // on the screen.
             Dimension size = new Dimension(1800, 1000);
             this.setPreferredSize(size);
@@ -70,7 +70,7 @@ public class Symbology extends ApplicationTemplate
             symbol.setShowLocation(false);
             layer.addRenderable(symbol);
 
-            // Add the symbol layer to the World Wind model.
+            // Add the symbol layer to the WorldWind model.
             this.getWwd().getModel().getLayers().add(layer);
         }
 
@@ -100,7 +100,7 @@ public class Symbology extends ApplicationTemplate
             // provides a visualization of how the control point positions affect the displayed graphic.
             this.addControlPoints(positions, layer);
 
-            // Add the graphic layer to the World Wind model.
+            // Add the graphic layer to the WorldWind model.
             this.getWwd().getModel().getLayers().add(layer);
         }
 
@@ -134,6 +134,6 @@ public class Symbology extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_LONGITUDE, -117.5250);
         Configuration.setValue(AVKey.INITIAL_ALTITUDE, 40000);
 
-        ApplicationTemplate.start("World Wind Symbology", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Symbology", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/symbology/TacticalGraphics.java
+++ b/src/gov/nasa/worldwindx/examples/symbology/TacticalGraphics.java
@@ -24,11 +24,11 @@ import java.util.*;
 import java.util.List;
 
 /**
- * Demonstrates how to create and display World Wind tactical graphics. See the <a title="Symbology Usage Guide"
+ * Demonstrates how to create and display WorldWind tactical graphics. See the <a title="Symbology Usage Guide"
  * href="https://goworldwind.org/developers-guide/symbology/" target="_blank">Symbology Usage Guide</a> for more
- * information on symbology support in World Wind.
+ * information on symbology support in WorldWind.
  * <p/>
- * See the {@link TacticalSymbols} for a detailed example of using World Wind tactical symbols in an application.
+ * See the {@link TacticalSymbols} for a detailed example of using WorldWind tactical symbols in an application.
  *
  * @author pabercrombie
  * @version $Id: TacticalGraphics.java 2109 2014-06-30 16:52:38Z tgaskins $
@@ -84,7 +84,7 @@ public class TacticalGraphics extends ApplicationTemplate
 
             this.addGraphicControls();
 
-            // Size the World Window to provide enough screen space for the graphics, and center the World Window
+            // Size the WorldWindow to provide enough screen space for the graphics, and center the WorldWindow
             // on the screen.
             Dimension size = new Dimension(1800, 1000);
             this.setPreferredSize(size);
@@ -945,7 +945,7 @@ public class TacticalGraphics extends ApplicationTemplate
                     sharedPointAttrs.setInteriorOpacity(opacity);
                     sharedPointAttrs.setOutlineOpacity(opacity);
 
-                    getWwd().redraw(); // Cause the World Window to refresh in order to make these changes visible.
+                    getWwd().redraw(); // Cause the WorldWindow to refresh in order to make these changes visible.
                 }
             });
             box.add(javax.swing.Box.createVerticalStrut(10));
@@ -966,7 +966,7 @@ public class TacticalGraphics extends ApplicationTemplate
                     this.setShowModifiers(lineLayer, tf);
                     this.setShowModifiers(areaLayer, tf);
 
-                    getWwd().redraw(); // Cause the World Window to refresh in order to make these changes visible.
+                    getWwd().redraw(); // Cause the WorldWindow to refresh in order to make these changes visible.
                 }
 
                 protected void setShowModifiers(RenderableLayer layer, boolean show)
@@ -994,7 +994,7 @@ public class TacticalGraphics extends ApplicationTemplate
                     this.setShowModifiers(lineLayer, tf);
                     this.setShowModifiers(areaLayer, tf);
 
-                    getWwd().redraw(); // Cause the World Window to refresh in order to make these changes visible.
+                    getWwd().redraw(); // Cause the WorldWindow to refresh in order to make these changes visible.
                 }
 
                 protected void setShowModifiers(RenderableLayer layer, boolean show)
@@ -1022,7 +1022,7 @@ public class TacticalGraphics extends ApplicationTemplate
                     this.setShowHostile(lineLayer, tf);
                     this.setShowHostile(areaLayer, tf);
 
-                    getWwd().redraw(); // Cause the World Window to refresh in order to make these changes visible.
+                    getWwd().redraw(); // Cause the WorldWindow to refresh in order to make these changes visible.
                 }
 
                 protected void setShowHostile(RenderableLayer layer, boolean show)
@@ -1048,6 +1048,6 @@ public class TacticalGraphics extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_LONGITUDE, -117.44);
         Configuration.setValue(AVKey.INITIAL_ALTITUDE, 155000);
 
-        ApplicationTemplate.start("World Wind Tactical Graphics", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Tactical Graphics", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/symbology/TacticalSymbols.java
+++ b/src/gov/nasa/worldwindx/examples/symbology/TacticalSymbols.java
@@ -23,11 +23,11 @@ import java.awt.*;
 import java.awt.event.*;
 
 /**
- * Demonstrates how to create and display World Wind tactical symbols. See the <a title="Symbology Usage Guide"
+ * Demonstrates how to create and display WorldWind tactical symbols. See the <a title="Symbology Usage Guide"
  * href="https://goworldwind.org/developers-guide/symbology/" target="_blank">Symbology Usage Guide</a> for more
- * information on symbology support in World Wind.
+ * information on symbology support in WorldWind.
  * <p/>
- * See the {@link TacticalGraphics} for a detailed example of using World Wind tactical graphics in an application.
+ * See the {@link TacticalGraphics} for a detailed example of using WorldWind tactical graphics in an application.
  *
  * @author dcollins
  * @version $Id: TacticalSymbols.java 2196 2014-08-06 19:42:15Z tgaskins $
@@ -45,7 +45,7 @@ public class TacticalSymbols extends ApplicationTemplate
         {
             // Create a renderable layer to display the tactical symbols. This example adds only three symbols, but many
             // symbols can be added to a single layer. Note that tactical symbols and tactical graphics can be combined
-            // in the same RenderableLayer, along with any World Wind object implementing the Renderable interface.
+            // in the same RenderableLayer, along with any WorldWind object implementing the Renderable interface.
             this.symbolLayer = new RenderableLayer();
             this.symbolLayer.setName("Tactical Symbols");
 
@@ -124,7 +124,7 @@ public class TacticalSymbols extends ApplicationTemplate
             machineGunSymbolAtDateline.setModifier(SymbologyConstants.DATE_TIME_GROUP, "30140000ZSEP97");
             this.symbolLayer.addRenderable(machineGunSymbolAtDateline);
 
-            // Add the symbol layer to the World Wind model.
+            // Add the symbol layer to the WorldWind model.
             this.getWwd().getModel().getLayers().add(symbolLayer);
 
             // Add a dragging controller to enable user click-and-drag control over tactical symbols.
@@ -134,7 +134,7 @@ public class TacticalSymbols extends ApplicationTemplate
             // Create a Swing control panel that provides user control over the symbol's appearance.
             this.addSymbolControls();
 
-            // Size the World Window to provide enough screen space for the symbols and center the World Window on the
+            // Size the WorldWindow to provide enough screen space for the symbols and center the WorldWindow on the
             // screen.
             Dimension size = new Dimension(1800, 1000);
             this.setPreferredSize(size);
@@ -161,7 +161,7 @@ public class TacticalSymbols extends ApplicationTemplate
                     double scale = (double) slider.getValue() / 100d;
                     sharedAttrs.setScale(scale);
                     sharedHighlightAttrs.setScale(scale);
-                    getWwd().redraw(); // Cause the World Window to refresh in order to make these changes visible.
+                    getWwd().redraw(); // Cause the WorldWindow to refresh in order to make these changes visible.
                 }
             });
             label.setAlignmentX(JComponent.LEFT_ALIGNMENT);
@@ -181,7 +181,7 @@ public class TacticalSymbols extends ApplicationTemplate
                     JSlider slider = (JSlider) changeEvent.getSource();
                     double opacity = (double) slider.getValue() / 100d;
                     sharedAttrs.setOpacity(opacity);
-                    getWwd().redraw(); // Cause the World Window to refresh in order to make these changes visible.
+                    getWwd().redraw(); // Cause the WorldWindow to refresh in order to make these changes visible.
                 }
             });
             box.add(Box.createVerticalStrut(10));
@@ -202,7 +202,7 @@ public class TacticalSymbols extends ApplicationTemplate
                     {
                         if (r instanceof TacticalSymbol)
                             ((TacticalSymbol) r).setShowGraphicModifiers(tf);
-                        getWwd().redraw(); // Cause the World Window to refresh in order to make these changes visible.
+                        getWwd().redraw(); // Cause the WorldWindow to refresh in order to make these changes visible.
                     }
                 }
             });
@@ -222,7 +222,7 @@ public class TacticalSymbols extends ApplicationTemplate
                     {
                         if (r instanceof TacticalSymbol)
                             ((TacticalSymbol) r).setShowTextModifiers(tf);
-                        getWwd().redraw(); // Cause the World Window to refresh in order to make these changes visible.
+                        getWwd().redraw(); // Cause the WorldWindow to refresh in order to make these changes visible.
                     }
                 }
             });
@@ -242,7 +242,7 @@ public class TacticalSymbols extends ApplicationTemplate
                     {
                         if (r instanceof TacticalSymbol)
                             ((MilStd2525TacticalSymbol) r).setShowFrame(tf);
-                        getWwd().redraw(); // Cause the World Window to refresh in order to make these changes visible.
+                        getWwd().redraw(); // Cause the WorldWindow to refresh in order to make these changes visible.
                     }
                 }
             });
@@ -262,7 +262,7 @@ public class TacticalSymbols extends ApplicationTemplate
                     {
                         if (r instanceof TacticalSymbol)
                             ((MilStd2525TacticalSymbol) r).setShowFill(tf);
-                        getWwd().redraw(); // Cause the World Window to refresh in order to make these changes visible.
+                        getWwd().redraw(); // Cause the WorldWindow to refresh in order to make these changes visible.
                     }
                 }
             });
@@ -282,7 +282,7 @@ public class TacticalSymbols extends ApplicationTemplate
                     {
                         if (r instanceof TacticalSymbol)
                             ((MilStd2525TacticalSymbol) r).setShowIcon(tf);
-                        getWwd().redraw(); // Cause the World Window to refresh in order to make these changes visible.
+                        getWwd().redraw(); // Cause the WorldWindow to refresh in order to make these changes visible.
                     }
                 }
             });
@@ -303,6 +303,6 @@ public class TacticalSymbols extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_PITCH, 82);
         Configuration.setValue(AVKey.INITIAL_ALTITUDE, 20000);
 
-        start("World Wind Tactical Symbols", AppFrame.class);
+        start("WorldWind Tactical Symbols", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/symbology/package.html
+++ b/src/gov/nasa/worldwindx/examples/symbology/package.html
@@ -14,9 +14,9 @@
 </head>
 <body>
 
-<p>Examples of displaying graphics from common symbology sets in World Wind. See the <a title="Symbology Usage Guide"
+<p>Examples of displaying graphics from common symbology sets in WorldWind. See the <a title="Symbology Usage Guide"
    href="https://goworldwind.org/developers-guide/symbology/" target="_blank">Symbology Usage Guide</a> for more
-   information on symbology support in World Wind.</p>
+   information on symbology support in WorldWind.</p>
 
 </body>
 </html>

--- a/src/gov/nasa/worldwindx/examples/tutorial/Cube.java
+++ b/src/gov/nasa/worldwindx/examples/tutorial/Cube.java
@@ -20,7 +20,7 @@ import java.awt.*;
 
 /**
  * Example of a custom {@link Renderable} that draws a cube at a geographic position. This class shows the simplest
- * possible example of a custom Renderable, while still following World Wind best practices. See
+ * possible example of a custom Renderable, while still following WorldWind best practices. See
  * https://goworldwind.org/developers-guide/how-to-build-a-custom-renderable/ for a complete description of this
  * example.
  *
@@ -307,6 +307,6 @@ public class Cube extends ApplicationTemplate implements Renderable
         Configuration.setValue(AVKey.INITIAL_PITCH, 45);
         Configuration.setValue(AVKey.INITIAL_HEADING, 45);
 
-        ApplicationTemplate.start("World Wind Custom Renderable Tutorial", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Custom Renderable Tutorial", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/util/BalloonResizeController.java
+++ b/src/gov/nasa/worldwindx/examples/util/BalloonResizeController.java
@@ -132,7 +132,7 @@ public class BalloonResizeController extends AbstractResizeHotSpot
     }
 
     /**
-    * Update the World Window's cursor to the current resize cursor.
+    * Update the WorldWindow's cursor to the current resize cursor.
     */
     protected void updateCursor()
     {

--- a/src/gov/nasa/worldwindx/examples/util/HighlightController.java
+++ b/src/gov/nasa/worldwindx/examples/util/HighlightController.java
@@ -13,7 +13,7 @@ import gov.nasa.worldwindx.applications.worldwindow.util.Util;
 
 /**
  * Controls highlighting of shapes implementing {@link Highlightable} in response to pick events. Monitors a specified
- * World Window for an indicated {@link gov.nasa.worldwind.event.SelectEvent} type and turns highlighting on and off in
+ * WorldWindow for an indicated {@link gov.nasa.worldwind.event.SelectEvent} type and turns highlighting on and off in
  * response.
  *
  * @author tag
@@ -26,9 +26,9 @@ public class HighlightController implements SelectListener
     protected Highlightable lastHighlightObject;
 
     /**
-     * Creates a controller for a specified World Window.
+     * Creates a controller for a specified WorldWindow.
      *
-     * @param wwd                the World Window to monitor.
+     * @param wwd                the WorldWindow to monitor.
      * @param highlightEventType the type of {@link SelectEvent} to highlight in response to. The default is {@link
      *                           SelectEvent#ROLLOVER}.
      */

--- a/src/gov/nasa/worldwindx/examples/util/HotSpotController.java
+++ b/src/gov/nasa/worldwindx/examples/util/HotSpotController.java
@@ -16,7 +16,7 @@ import java.awt.*;
 import java.awt.event.*;
 
 /**
- * Controller to forward selection, keyboard, and mouse events on the World Window to the active {@link
+ * Controller to forward selection, keyboard, and mouse events on the WorldWindow to the active {@link
  * gov.nasa.worldwind.util.HotSpot}. The active HotSpot is updated on {@link gov.nasa.worldwind.event.SelectEvent#ROLLOVER}
  * select events, but not during a drag operation. This ensures that the active HotSpot remains active while it's being
  * dragged, regardless of what's under the cursor.
@@ -39,10 +39,10 @@ public class HotSpotController implements SelectListener, MouseMotionListener
     protected boolean customCursor;
 
     /**
-     * Creates a new HotSpotController for a specified World Window, and assigns the controller as a {@link
-     * gov.nasa.worldwind.event.SelectListener} on the World Window.
+     * Creates a new HotSpotController for a specified WorldWindow, and assigns the controller as a {@link
+     * gov.nasa.worldwind.event.SelectListener} on the WorldWindow.
      *
-     * @param wwd The World Window to monitor selection events for.
+     * @param wwd The WorldWindow to monitor selection events for.
      */
     public HotSpotController(WorldWindow wwd)
     {
@@ -65,7 +65,7 @@ public class HotSpotController implements SelectListener, MouseMotionListener
      * This forwards the select event to {@link #doSelected(gov.nasa.worldwind.event.SelectEvent)}, and catches and logs
      * any exceptions thrown by {@code doSelected}.
      *
-     * @param event A select event on the World Window we're monitoring.
+     * @param event A select event on the WorldWindow we're monitoring.
      */
     public void selected(SelectEvent event)
     {
@@ -90,7 +90,7 @@ public class HotSpotController implements SelectListener, MouseMotionListener
      * gov.nasa.worldwind.event.SelectEvent#ROLLOVER} while not dragging - Updates the active HotSpot, then forwards the
      * event to the active HotSpot.</li> <li>Other event types - forwards the event to the active HotSpot</li> </ul>
      *
-     * @param event A select event on the World Window we're monitoring.
+     * @param event A select event on the WorldWindow we're monitoring.
      */
     protected void doSelected(SelectEvent event)
     {
@@ -117,7 +117,7 @@ public class HotSpotController implements SelectListener, MouseMotionListener
             // press events when we're not dragging. This ensures that the active HotSpot remains active while it's
             // being dragged, regardless of what's under the cursor. It's necessary to do this on left press to handle
             // cases in which the mouse starts dragging without a hover event, which can happen if the user starts
-            // dragging while the World Wind window is in the background.
+            // dragging while the WorldWind window is in the background.
             PickedObject po = event.getTopPickedObject();
             this.updateActiveHotSpot(po);
         }
@@ -199,10 +199,10 @@ public class HotSpotController implements SelectListener, MouseMotionListener
     /**
      * Sets the active {@link gov.nasa.worldwind.util.HotSpot} to the specified HotSpot. The HotSpot may be {@code
      * null}, indicating that there is no active HotSpot. This registers the new HotSpot as key listener, mouse
-     * listener, mouse motion listener, and mouse wheel listener on the World Window's {@link
+     * listener, mouse motion listener, and mouse wheel listener on the WorldWindow's {@link
      * gov.nasa.worldwind.event.InputHandler}. This removes the previously active HotSpot as a listener on the World
      * Window's InputHandler. This does nothing if the active HotSpot and the specified HotSpot are the same object.
-     * </p> Additionally, this updates the World Window's {@link java.awt.Cursor} to the value returned by {@code
+     * </p> Additionally, this updates the WorldWindow's {@link java.awt.Cursor} to the value returned by {@code
      * hotSpot.getCursor()}, or {@code null} if the specified hotSpot is {@code null}.
      *
      * @param hotSpot The HotSpot that becomes the active HotSpot. {@code null} to indicate that there is no active
@@ -210,8 +210,8 @@ public class HotSpotController implements SelectListener, MouseMotionListener
      */
     protected void setActiveHotSpot(HotSpot hotSpot)
     {
-        // Update the World Window's cursor to the cursor associated with the active HotSpot. We
-        // specify null if there's no active HotSpot, which tells the World Window to use the default
+        // Update the WorldWindow's cursor to the cursor associated with the active HotSpot. We
+        // specify null if there's no active HotSpot, which tells the WorldWindow to use the default
         // cursor, or inherit its cursor from the parent Component.
         if (this.wwd instanceof Component)
         {

--- a/src/gov/nasa/worldwindx/examples/util/LayerManagerLayer.java
+++ b/src/gov/nasa/worldwindx/examples/util/LayerManagerLayer.java
@@ -88,7 +88,7 @@ public class LayerManagerLayer extends RenderableLayer implements SelectListener
         this.annotation.getAttributes().setBorderWidth(1);
         this.addRenderable(this.annotation);
 
-        // Listen to world window for select event
+        // Listen to WorldWindow for select event
         this.wwd.addSelectListener(this);
     }
 
@@ -584,7 +584,7 @@ public class LayerManagerLayer extends RenderableLayer implements SelectListener
                 {
                     boolean wasDraggingLayer = this.draggingLayer;
                     this.drag(event);
-                    // Update list if dragging a layer, otherwise just redraw the world window
+                    // Update list if dragging a layer, otherwise just redraw the WorldWindow
                     if (this.draggingLayer || wasDraggingLayer)
                         update = true;
                     else

--- a/src/gov/nasa/worldwindx/examples/util/ScreenSelector.java
+++ b/src/gov/nasa/worldwindx/examples/util/ScreenSelector.java
@@ -373,7 +373,7 @@ public class ScreenSelector extends WWObjectImpl implements MouseListener, Mouse
         if (!this.getLayer().isEnabled())
             this.getLayer().setEnabled(true);
 
-        // Listen for mouse input on the World Window.
+        // Listen for mouse input on the WorldWindow.
         this.getWwd().getInputHandler().addMouseListener(this);
         this.getWwd().getInputHandler().addMouseMotionListener(this);
     }
@@ -390,7 +390,7 @@ public class ScreenSelector extends WWObjectImpl implements MouseListener, Mouse
         // Remove the layer that displays this ScreenSelector's selection rectangle.
         this.getWwd().getModel().getLayers().remove(this.getLayer());
 
-        // Stop listening for mouse input on the world window.
+        // Stop listening for mouse input on the WorldWindow.
         this.getWwd().getInputHandler().removeMouseListener(this);
         this.getWwd().getInputHandler().removeMouseMotionListener(this);
     }
@@ -526,9 +526,9 @@ public class ScreenSelector extends WWObjectImpl implements MouseListener, Mouse
 
     protected void selectionChanged(MouseEvent mouseEvent)
     {
-        // Limit the end point to the World Window's viewport rectangle. This ensures that a user drag event to define
+        // Limit the end point to the WorldWindow's viewport rectangle. This ensures that a user drag event to define
         // the selection does not exceed the viewport and the viewing frustum. This is only necessary during mouse drag
-        // events because those events are reported when the cursor is outside the World Window's viewport.
+        // events because those events are reported when the cursor is outside the WorldWindow's viewport.
         Point p = this.limitPointToWorldWindow(mouseEvent.getPoint());
 
         // Specify the selection's end point and set the scene controller's pick rectangle to the selected rectangle.
@@ -541,15 +541,15 @@ public class ScreenSelector extends WWObjectImpl implements MouseListener, Mouse
     }
 
     /**
-     * Limits the specified point's x and y coordinates to the World Window's viewport, and returns a new point with the
-     * limited coordinates. For example, if the World Window's viewport rectangle is x=0, y=0, width=100, height=100 and
+     * Limits the specified point's x and y coordinates to the WorldWindow's viewport, and returns a new point with the
+     * limited coordinates. For example, if the WorldWindow's viewport rectangle is x=0, y=0, width=100, height=100 and
      * the point's coordinates are x=50, y=200 this returns a new point with coordinates x=50, y=100. If the specified
-     * point is already inside the World Window's viewport, this returns a new point with the same x and y coordinates
+     * point is already inside the WorldWindow's viewport, this returns a new point with the same x and y coordinates
      * as the specified point.
      *
      * @param point the point to limit.
      *
-     * @return a new Point representing the specified point limited to the World Window's viewport rectangle.
+     * @return a new Point representing the specified point limited to the WorldWindow's viewport rectangle.
      */
     protected Point limitPointToWorldWindow(Point point)
     {

--- a/src/gov/nasa/worldwindx/examples/util/ShapefileLoader.java
+++ b/src/gov/nasa/worldwindx/examples/util/ShapefileLoader.java
@@ -14,15 +14,15 @@ import gov.nasa.worldwind.render.*;
 import gov.nasa.worldwind.util.*;
 
 /**
- * Converts Shapefile geometry into World Wind renderable objects. Shapefile geometries are mapped to World Wind objects
- * as follows: <table> <tr><th>Shapefile Geometry</th><th>World Wind Object</th></tr> <tr><td>Point</td><td>{@link
+ * Converts Shapefile geometry into WorldWind renderable objects. Shapefile geometries are mapped to WorldWind objects
+ * as follows: <table> <tr><th>Shapefile Geometry</th><th>WorldWind Object</th></tr> <tr><td>Point</td><td>{@link
  * gov.nasa.worldwind.render.WWIcon}</td></tr> <tr><td>MultiPoint</td><td>List of {@link
  * gov.nasa.worldwind.render.WWIcon}</td></tr> <tr><td>Polyline</td><td>{@link gov.nasa.worldwind.render.SurfacePolylines}</td></tr>
  * <tr><td>Polygon</td><td>{@link gov.nasa.worldwind.render.SurfacePolygons}</td></tr> </table>
  * <p/>
  * Shapefiles do not contain a standard definition for color and other visual attributes. Though some Shapefiles contain
  * color information in each record's key-value attributes, ShapefileLoader does not attempt to interpret that
- * information. Instead, the World Wind renderable objects created by ShapefileLoader are assigned a random color.
+ * information. Instead, the WorldWind renderable objects created by ShapefileLoader are assigned a random color.
  * Callers can replace or extend this behavior by defining a subclass of ShapefileLoader and overriding the following
  * methods: <ul> <li>{@link #nextPointAttributes()}</li> <li>{@link #nextPolylineAttributes()}</li> <li>{@link
  * #nextPolygonAttributes()}</li></ul>.

--- a/src/gov/nasa/worldwindx/examples/util/ToolTipController.java
+++ b/src/gov/nasa/worldwindx/examples/util/ToolTipController.java
@@ -34,7 +34,7 @@ public class ToolTipController implements SelectListener, Disposable
     /**
      * Create a controller for a specified {@link WorldWindow} that displays tool tips on hover and/or rollover.
      *
-     * @param wwd         the World Window to monitor.
+     * @param wwd         the WorldWindow to monitor.
      * @param rolloverKey the key to use when looking up tool tip text from the shape's AVList when a rollover event
      *                    occurs. May be null, in which case a tool tip is not displayed for rollover events.
      * @param hoverKey    the key to use when looking up tool tip text from the shape's AVList when a hover event
@@ -52,7 +52,7 @@ public class ToolTipController implements SelectListener, Disposable
     /**
      * Create a controller for a specified {@link WorldWindow} that displays "DISPLAY_NAME" on rollover.
      *
-     * @param wwd         the World Window to monitor.
+     * @param wwd         the WorldWindow to monitor.
      */
     public ToolTipController(WorldWindow wwd)
     {

--- a/src/gov/nasa/worldwindx/examples/util/WCSCoveragePanel.java
+++ b/src/gov/nasa/worldwindx/examples/util/WCSCoveragePanel.java
@@ -189,7 +189,7 @@ public class WCSCoveragePanel extends JPanel
 
         public void actionPerformed(ActionEvent actionEvent)
         {
-            // If the coverage is selected, add it to the world window's current model, else remove it from the model.
+            // If the coverage is selected, add it to the WorldWindow's current model, else remove it from the model.
             if (((JCheckBox) actionEvent.getSource()).isSelected())
             {
                 if (this.component == null)
@@ -203,7 +203,7 @@ public class WCSCoveragePanel extends JPanel
                     updateComponent(this.component, false);
             }
 
-            // Tell the world window to update.
+            // Tell the WorldWindow to update.
             wwd.redraw();
         }
     }
@@ -244,7 +244,7 @@ public class WCSCoveragePanel extends JPanel
     {
         AVList configParams = coverageInfo.params.copy(); // Copy to insulate changes from the caller.
 
-        // Some wcs servers are slow, so increase the timeouts and limits used by world wind's retrievers.
+        // Some wcs servers are slow, so increase the timeouts and limits used by WorldWind's retrievers.
         configParams.setValue(AVKey.URL_CONNECT_TIMEOUT, 30000);
         configParams.setValue(AVKey.URL_READ_TIMEOUT, 30000);
         configParams.setValue(AVKey.RETRIEVAL_QUEUE_STALE_REQUEST_LIMIT, 60000);

--- a/src/gov/nasa/worldwindx/examples/util/cachecleaner/DataCacheViewer.java
+++ b/src/gov/nasa/worldwindx/examples/util/cachecleaner/DataCacheViewer.java
@@ -208,7 +208,7 @@ public class DataCacheViewer
     {
         if (Configuration.isMacOS())
         {
-            System.setProperty("com.apple.mrj.application.apple.menu.about.name", "World Wind Cache Cleaner");
+            System.setProperty("com.apple.mrj.application.apple.menu.about.name", "WorldWind Cache Cleaner");
         }
     }
 

--- a/src/gov/nasa/worldwindx/examples/view/AddAnimator.java
+++ b/src/gov/nasa/worldwindx/examples/view/AddAnimator.java
@@ -111,6 +111,6 @@ public class AddAnimator extends ApplicationTemplate
     {
         // Call the static start method like this from the main method of your derived class.
         // Substitute your application's name for the first argument.
-        ApplicationTemplate.start("World Wind View Animator", AppFrame.class);
+        ApplicationTemplate.start("WorldWind View Animator", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/examples/view/ViewSwitch.java
+++ b/src/gov/nasa/worldwindx/examples/view/ViewSwitch.java
@@ -307,6 +307,6 @@ public class ViewSwitch extends ApplicationTemplate
     {
         // Call the static start method like this from the main method of your derived class.
         // Substitute your application's name for the first argument.
-        ApplicationTemplate.start("World Wind Switch Views", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Switch Views", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/performance/AirspacesEverywhere.java
+++ b/src/gov/nasa/worldwindx/performance/AirspacesEverywhere.java
@@ -89,6 +89,6 @@ public class AirspacesEverywhere extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Very Many Airspaces", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Very Many Airspaces", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/performance/EllipsoidsEverywhere.java
+++ b/src/gov/nasa/worldwindx/performance/EllipsoidsEverywhere.java
@@ -277,6 +277,6 @@ public class EllipsoidsEverywhere extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Very Many Shapes", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Very Many Shapes", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/performance/ExtrudedPolygonsEverywhere.java
+++ b/src/gov/nasa/worldwindx/performance/ExtrudedPolygonsEverywhere.java
@@ -110,6 +110,6 @@ public class ExtrudedPolygonsEverywhere extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Very Many Extruded Polygons", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Very Many Extruded Polygons", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/performance/PointPlacemarksEverywhere.java
+++ b/src/gov/nasa/worldwindx/performance/PointPlacemarksEverywhere.java
@@ -65,6 +65,6 @@ public class PointPlacemarksEverywhere extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Very Many Point Placemarks", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Very Many Point Placemarks", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/performance/PolygonsEverywhere.java
+++ b/src/gov/nasa/worldwindx/performance/PolygonsEverywhere.java
@@ -97,6 +97,6 @@ public class PolygonsEverywhere extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Very Many Polygons", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Very Many Polygons", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/performance/SurfacePolygonsEverywhere.java
+++ b/src/gov/nasa/worldwindx/performance/SurfacePolygonsEverywhere.java
@@ -92,6 +92,6 @@ public class SurfacePolygonsEverywhere extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Very Many Surface Polygons", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Very Many Surface Polygons", AppFrame.class);
     }
 }

--- a/src/gov/nasa/worldwindx/performance/VeryManyPaths.java
+++ b/src/gov/nasa/worldwindx/performance/VeryManyPaths.java
@@ -95,6 +95,6 @@ public class VeryManyPaths extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        ApplicationTemplate.start("World Wind Paths", AppFrame.class);
+        ApplicationTemplate.start("WorldWind Paths", AppFrame.class);
     }
 }

--- a/src/overview.html
+++ b/src/overview.html
@@ -3,9 +3,9 @@
 <body>
 
 <p>
-    World Wind is a collection of components that interactively display 3D geographic information within Java
-    applications. Applications use World Wind by placing one or more {@link gov.nasa.worldwind.WorldWindow} components
-    in their user interface. The World Wind components are extensible. The API is defined primarily by interfaces, so
+    WorldWind is a collection of components that interactively display 3D geographic information within Java
+    applications. Applications use WorldWind by placing one or more {@link gov.nasa.worldwind.WorldWindow} components
+    in their user interface. The WorldWind components are extensible. The API is defined primarily by interfaces, so
     components can be selectively replaced by alternative components.</p>
 
 <p>
@@ -14,7 +14,7 @@
                              gov.nasa.worldwind.awt.WorldWindowGLCanvas}.</p>
 
 <p>
-    In addition to <code>WorldWindow</code>, there are five major World Wind interfaces. They are:</p>
+    In addition to <code>WorldWindow</code>, there are five major WorldWind interfaces. They are:</p>
 <ul>
     <li>{@link gov.nasa.worldwind.globes.Globe} &mdash; represents a planet's shape and terrain.</li>
     <li>{@link gov.nasa.worldwind.layers.Layer} &mdash; applies imagery or information to a <code>Globe</code>.</li>
@@ -33,28 +33,28 @@
     conjunction with an interactive <code>View</code> that defines the user's view of the planet. </p>
 
 <p>
-    The objects implementing the above interfaces may be those provided by World Wind or those created by application
+    The objects implementing the above interfaces may be those provided by WorldWind or those created by application
     developers. Objects implementing a particular interface may be used wherever that interface is called for. World
     Wind provides several <code>Globe</code> objects representing Earth, Mars and the Earth's moon, and provides basic
     implementations of <code>Model</code>, <code>SceneController</code> and <code>View</code>. </p>
 
 <p>
-    Most of World Wind's components are defined by interfaces. This allows application developers to create their own
-    implementations and easily integrate them into World Wind. </p>
+    Most of WorldWind's components are defined by interfaces. This allows application developers to create their own
+    implementations and easily integrate them into WorldWind. </p>
 
 <h2>The <code>WorldWind</code> Class</h2>
 
 <p>TODO</p>
 
-<h2>Multiple World Wind Windows</h2>
+<h2>Multiple WorldWind Windows</h2>
 
 <p>TODO</p>
 
 <h2>Data Retrieval</h2>
 
 <p>
-    World Wind works with enormous quantities of data and information, all of which exist primarily on remote data
-    servers. Retrieval and local caching of that data is therefore a primary feature of World Wind. The classes that
+    WorldWind works with enormous quantities of data and information, all of which exist primarily on remote data
+    servers. Retrieval and local caching of that data is therefore a primary feature of WorldWind. The classes that
     implement retrieval are {@link gov.nasa.worldwind.retrieve.Retriever} and {@link
     gov.nasa.worldwind.retrieve.RetrievalService}. </p>
 
@@ -83,7 +83,7 @@
 
 <p>
     Data that has been previously retrieved or is otherwise local (on disk) is brought into memory in a thread separate
-    from the event-dispatching thread or the rendering thread. One of the World Wind conventions is that no code may
+    from the event-dispatching thread or the rendering thread. One of the WorldWind conventions is that no code may
     access the computer's disk in any way during rendering. Therefore loading the data from disk is dispatched to
     another thread pool, the {@link gov.nasa.worldwind.util.ThreadedTaskService}. This service has a similar interface
     to RetrievalService. Tasks it runs typically read the data from disk and add it to the global memory cache
@@ -101,7 +101,7 @@
 
 <h2>Memory Cache</h2>
 
-<p>So that data can be shared among caching objects, most cached data used within World Wind is cached in a {@link
+<p>So that data can be shared among caching objects, most cached data used within WorldWind is cached in a {@link
    gov.nasa.worldwind.cache.MemoryCache}. <code>MemoryCache</code> enable cached data to be shared among all
    WorldWindWindow instantiations in an application. Thus two Earth globes each displayed in a separate window will
    share any image or elevation tiles that they are using simultaneously. The same would be true of any place name
@@ -116,7 +116,7 @@
 
 <h2>Picking and Selection</h2>
 
-<p>World Wind can determine the displayed objects at a given screen position in a <code>WorldWindow</code>. When the
+<p>WorldWind can determine the displayed objects at a given screen position in a <code>WorldWindow</code>. When the
    application wants to know what's displayed at a particular point, say the cursor position, it calls a method on
     <code>WorldWindow</code> that accepts the point and returns a description of what's drawn there. In general the
    application specifies a pick region rather than a single point, with the region a few pixels wide and high and
@@ -124,7 +124,7 @@
    exactly at the screen position. Since several objects may intersect the pick region, descriptions of all these
    objects are returned to the application. Which of these objects are meaningful is determined by the application.</p>
 
-<p>World Wind uses a method similar to drawing to detect objects in the pick region. During picking, the frame
+<p>WorldWind uses a method similar to drawing to detect objects in the pick region. During picking, the frame
    controller invokes each layer's {@link gov.nasa.worldwind.layers.AbstractLayer#doPick(DrawContext, java.awt.Point)}.
    As in drawing, the methods are invoked in turn, according to the layer's position in the model's layer list. During
    the call, each layer is responsible for determining which of its items, if any, are picked. Prior to traversing the
@@ -136,7 +136,7 @@
    region. To do that usually requires transforming the screen point into model coordinates and determining intersection
    in that coordinate system. But depth values are ambiguous with only a two-dimensional screen point as input,
    complicating transformation to model coordinates, and geometric intersection determination can be very difficult and
-   time consuming. To overcome this, World Wind implements a widely used method of sampling the window's color buffer to
+   time consuming. To overcome this, WorldWind implements a widely used method of sampling the window's color buffer to
    detect intersection, and makes this method easy for layers to use.</p>
 
 <p>The method works as follows: The frame controller precedes a pick traversal by first setting the current view's
@@ -155,7 +155,7 @@
    can compare their pick identifiers with the final colors and mark themselves as "on top." The application then
    receives the full list of picked items, with the truly visible ones marked as such.</p>
 
-<p>World Wind provides utility classes to make it simple for layers to participate in this picking scheme. See {@link
+<p>WorldWind provides utility classes to make it simple for layers to participate in this picking scheme. See {@link
    gov.nasa.worldwind.pick.PickSupport} </p>
 
 <h2>Use of Proxies</h2>
@@ -172,8 +172,8 @@
 
 <h2>Offline Mode</h2>
 
-<p>World Wind's use of the network can be disabled by calling {@link gov.nasa.worldwind.WorldWind#setOfflineMode}. Prior
-   to attempting retrieval of a network resource &mdash; anything addressed by a URL &mdash; World Wind checks the
+<p>WorldWind's use of the network can be disabled by calling {@link gov.nasa.worldwind.WorldWind#setOfflineMode}. Prior
+   to attempting retrieval of a network resource &mdash; anything addressed by a URL &mdash; WorldWind checks the
    offline-mode setting and does not attempt retrieval if the value is true.</p>
 
 <h2><a name="path-types">Path Types</a></h2>

--- a/test/gov/nasa/worldwind/ogc/wcs/WCSCapabilitiesParsingTest.java
+++ b/test/gov/nasa/worldwind/ogc/wcs/WCSCapabilitiesParsingTest.java
@@ -49,13 +49,13 @@ public class WCSCapabilitiesParsingTest
 
         String description = service.getDescription();
         assertNotNull("Service description is null", description);
-        assertTrue("Incorrect description", description.startsWith("World Wind MapServer Elevation test"));
+        assertTrue("Incorrect description", description.startsWith("WorldWind MapServer Elevation test"));
 
         assertNotNull("Service name is null", service.getName());
         assertEquals("Incorrect service name", "MapServer WCS", service.getName());
 
         assertNotNull("Service label is null", service.getLabel());
-        assertEquals("Incorrect service label", "World Wind MapServer Elevation", service.getLabel());
+        assertEquals("Incorrect service label", "WorldWind MapServer Elevation", service.getLabel());
 
         List<String> keywords = service.getKeywords();
         assertTrue("Keywords is null", keywords != null);

--- a/test/gov/nasa/worldwind/util/NetworkStatusTest.java
+++ b/test/gov/nasa/worldwind/util/NetworkStatusTest.java
@@ -60,7 +60,7 @@ public class NetworkStatusTest
     public void testWorldWindAvailable()
     {
         boolean tf = this.netStat.isWorldWindServerUnavailable();
-        assertFalse("World Wind server unavailable test ", tf);
+        assertFalse("WorldWind server unavailable test ", tf);
     }
 
     @Test

--- a/testData/KML/NetworkLink01.kml
+++ b/testData/KML/NetworkLink01.kml
@@ -17,7 +17,7 @@
                 <text>
                     <![CDATA[
                         <h3>Balloon With Remote Link</h3>
-                        Open <a href="http://worldwind.arc.nasa.gov" target="_blank">World Wind Java</a> website in a new window.
+                        Open <a href="http://worldwind.arc.nasa.gov" target="_blank">WorldWind Java</a> website in a new window.
                         ]]>
                 </text>
             </BalloonStyle>

--- a/testData/WCS/WCSCapabilities003.xml
+++ b/testData/WCS/WCSCapabilities003.xml
@@ -7,9 +7,9 @@
 
 <WCS_Capabilities version="1.0.0" updateSequence="2013-06-28T16:26:00Z" xmlns="http://www.opengis.net/wcs" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wcs http://schemas.opengis.net/wcs/1.0.0/wcsCapabilities.xsd">
 <Service>
-  <metadataLink metadataType="TC211" xlink:type="simple" xlink:href="http://worldwind26.arc.nasa.gov"/>  <description>World Wind MapServer Elevation test</description>
+  <metadataLink metadataType="TC211" xlink:type="simple" xlink:href="http://worldwind26.arc.nasa.gov"/>  <description>WorldWind MapServer Elevation test</description>
   <name>MapServer WCS</name>
-  <label>World Wind MapServer Elevation</label>
+  <label>WorldWind MapServer Elevation</label>
   <keywords>
     <keyword>wcs</keyword>
     <keyword>test</keyword>

--- a/testFunctional/gov/nasa/worldwind/ogc/collada/ColladaMovingModel.java
+++ b/testFunctional/gov/nasa/worldwind/ogc/collada/ColladaMovingModel.java
@@ -15,7 +15,7 @@ import java.awt.event.*;
 import java.io.File;
 
 /**
- * Test loading a COLLADA model and moving the model along a path. World Wind does not support animations defined in
+ * Test loading a COLLADA model and moving the model along a path. WorldWind does not support animations defined in
  * COLLADA files, but models may be animated by application logic.
  *
  * @author pabercrombie
@@ -62,7 +62,7 @@ public class ColladaMovingModel extends ColladaViewer
         Configuration.setValue(AVKey.INITIAL_ALTITUDE, 4000);
         Configuration.setValue(AVKey.INITIAL_PITCH, 50);
 
-        final AppFrame af = (AppFrame) start("World Wind COLLADA Viewer", AppFrame.class);
+        final AppFrame af = (AppFrame) start("WorldWind COLLADA Viewer", AppFrame.class);
 
         new WorkerThread(new File("testData/collada/duck_triangulate.dae"),
             Position.fromDegrees(40.00779229910037, -105.27494931422459, 100), af).start();

--- a/testFunctional/gov/nasa/worldwind/ogc/collada/ColladaViewer.java
+++ b/testFunctional/gov/nasa/worldwind/ogc/collada/ColladaViewer.java
@@ -32,7 +32,7 @@ public class ColladaViewer extends ApplicationTemplate
         {
             super(true, true, false); // Don't include the layer panel; we're using the on-screen layer tree.
 
-            // Size the World Window to take up the space typically used by the layer panel.
+            // Size the WorldWindow to take up the space typically used by the layer panel.
             Dimension size = new Dimension(1400, 800);
             this.setPreferredSize(size);
             this.pack();
@@ -47,7 +47,7 @@ public class ColladaViewer extends ApplicationTemplate
          */
         protected void addColladaLayer(ColladaRoot colladaRoot)
         {
-            // Create a ColladaController to adapt the ColladaRoot to the World Wind renderable interface.
+            // Create a ColladaController to adapt the ColladaRoot to the WorldWind renderable interface.
             ColladaController colladaController = new ColladaController(colladaRoot);
 
             // Adds a new layer containing the ColladaRoot to the end of the WorldWindow's layer list.
@@ -121,7 +121,7 @@ public class ColladaViewer extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_ALTITUDE, 4000);
         Configuration.setValue(AVKey.INITIAL_PITCH, 50);
 
-        final AppFrame af = (AppFrame) start("World Wind COLLADA Viewer", AppFrame.class);
+        final AppFrame af = (AppFrame) start("WorldWind COLLADA Viewer", AppFrame.class);
 
         new WorkerThread(new File("testData/collada/collada.dae"),
             Position.fromDegrees(40.009993372683, -105.272774533734, 300), af).start();

--- a/testFunctional/gov/nasa/worldwind/ogc/kml/KMLManualTest.html
+++ b/testFunctional/gov/nasa/worldwind/ogc/kml/KMLManualTest.html
@@ -14,7 +14,7 @@
 </head>
 <body>
 
-<p>Describes the steps to execute a manual validation test of the World Wind KML implementation.</p>
+<p>Describes the steps to execute a manual validation test of the WorldWind KML implementation.</p>
 
 <h4>Tests Files</h4>
 All tests files are located at <a href="http://wwdev.tomgaskins.net/KMLTestFiles">http://wwdev.tomgaskins.net/KMLTestFiles</a>.

--- a/testFunctional/gov/nasa/worldwind/ogc/kml/StyleLocationTests.java
+++ b/testFunctional/gov/nasa/worldwind/ogc/kml/StyleLocationTests.java
@@ -649,7 +649,7 @@ public class StyleLocationTests extends ApplicationTemplate
 
     public static void main(String[] args)
     {
-        final AppFrame af = (AppFrame) ApplicationTemplate.start("World Wind KML Style Location Tests", AppFrame.class);
+        final AppFrame af = (AppFrame) ApplicationTemplate.start("WorldWind KML Style Location Tests", AppFrame.class);
 
         SwingUtilities.invokeLater(new Runnable()
         {

--- a/testFunctional/gov/nasa/worldwind/render/BrowserBalloonSizeTest.java
+++ b/testFunctional/gov/nasa/worldwind/render/BrowserBalloonSizeTest.java
@@ -41,7 +41,7 @@ public class BrowserBalloonSizeTest extends ApplicationTemplate
             // Add a controller to display balloons when placemarks are clicked.
             this.balloonController = new BalloonController(this.getWwd());
 
-            // Size the World Window to take up the space typically used by the layer panel.
+            // Size the WorldWindow to take up the space typically used by the layer panel.
             Dimension size = new Dimension(1000, 800);
             this.setPreferredSize(size);
             this.pack();

--- a/testFunctional/gov/nasa/worldwind/render/BrowserBalloonTest.html
+++ b/testFunctional/gov/nasa/worldwind/render/BrowserBalloonTest.html
@@ -16,7 +16,7 @@
 
 <h1>BrowserBalloon Manual Tests</h1>
 
-<p>Describes the steps to execute a manual validation test of the World Wind BrowserBalloon implementation.</p>
+<p>Describes the steps to execute a manual validation test of the WorldWind BrowserBalloon implementation.</p>
 <p>Run gov.nasa.worldwind.render.BrowserBalloonTest. Use the File menu to open local files or URLs in the BrowserBalloon.
 </p>
 

--- a/testFunctional/gov/nasa/worldwind/render/BrowserBalloonTest.java
+++ b/testFunctional/gov/nasa/worldwind/render/BrowserBalloonTest.java
@@ -47,7 +47,7 @@ public class BrowserBalloonTest extends ApplicationTemplate
             // tree.
             this.balloonController = new BalloonController(this.getWwd());
 
-            // Size the World Window to take up the space typically used by the layer panel.
+            // Size the WorldWindow to take up the space typically used by the layer panel.
             Dimension size = new Dimension(1000, 600);
             this.setPreferredSize(size);
             this.pack();

--- a/testFunctional/gov/nasa/worldwind/symbology/milstd2525/AllModifiers.java
+++ b/testFunctional/gov/nasa/worldwind/symbology/milstd2525/AllModifiers.java
@@ -34,7 +34,7 @@ public class AllModifiers extends ApplicationTemplate
 
             this.addSymbols();
 
-            // Size the World Window to provide enough screen space for the symbols and center the World Window on the
+            // Size the WorldWindow to provide enough screen space for the symbols and center the WorldWindow on the
             // screen.
             Dimension size = new Dimension(1800, 1000);
             this.setPreferredSize(size);
@@ -104,7 +104,7 @@ public class AllModifiers extends ApplicationTemplate
                 lon = startLon;
             }
 
-            // Add the symbol layer to the World Wind model.
+            // Add the symbol layer to the WorldWind model.
             this.getWwd().getModel().getLayers().add(layer);
         }
 
@@ -126,7 +126,7 @@ public class AllModifiers extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_LONGITUDE, -119.85);
         Configuration.setValue(AVKey.INITIAL_ALTITUDE, 77000);
 
-        start("World Wind All MIL-STD-2525 Tactical Symbols", AppFrame.class);
+        start("WorldWind All MIL-STD-2525 Tactical Symbols", AppFrame.class);
     }
 
     protected static java.util.List<String> standardIdentities = Arrays.asList(

--- a/testFunctional/gov/nasa/worldwind/symbology/milstd2525/AllPointGraphics.java
+++ b/testFunctional/gov/nasa/worldwind/symbology/milstd2525/AllPointGraphics.java
@@ -70,7 +70,7 @@ public class AllPointGraphics extends ApplicationTemplate
 
             this.addGraphicControls();
 
-            // Size the World Window to provide enough screen space for the graphics, and center the World Window
+            // Size the WorldWindow to provide enough screen space for the graphics, and center the WorldWindow
             // on the screen.
             Dimension size = new Dimension(1800, 1000);
             this.setPreferredSize(size);
@@ -235,7 +235,7 @@ public class AllPointGraphics extends ApplicationTemplate
                     double scale = (double) slider.getValue() / 100d;
                     sharedAttrs.setScale(scale);
                     sharedHighlightAttrs.setScale(scale);
-                    getWwd().redraw(); // Cause the World Window to refresh in order to make these changes visible.
+                    getWwd().redraw(); // Cause the WorldWindow to refresh in order to make these changes visible.
                 }
             });
             label.setAlignmentX(JComponent.LEFT_ALIGNMENT);
@@ -255,7 +255,7 @@ public class AllPointGraphics extends ApplicationTemplate
                     JSlider slider = (JSlider) changeEvent.getSource();
                     double opacity = (double) slider.getValue() / 100d;
                     sharedAttrs.setInteriorOpacity(opacity);
-                    getWwd().redraw(); // Cause the World Window to refresh in order to make these changes visible.
+                    getWwd().redraw(); // Cause the WorldWindow to refresh in order to make these changes visible.
                 }
             });
             box.add(javax.swing.Box.createVerticalStrut(10));
@@ -282,7 +282,7 @@ public class AllPointGraphics extends ApplicationTemplate
                         if (r instanceof TacticalGraphic)
                             ((TacticalGraphic) r).setShowTextModifiers(tf);
                     }
-                    getWwd().redraw(); // Cause the World Window to refresh in order to make these changes visible.
+                    getWwd().redraw(); // Cause the WorldWindow to refresh in order to make these changes visible.
                 }
             });
             cb.setAlignmentX(JComponent.LEFT_ALIGNMENT);
@@ -307,7 +307,7 @@ public class AllPointGraphics extends ApplicationTemplate
                         if (r instanceof TacticalGraphic)
                             ((TacticalGraphic) r).setShowGraphicModifiers(tf);
                     }
-                    getWwd().redraw(); // Cause the World Window to refresh in order to make these changes visible.
+                    getWwd().redraw(); // Cause the WorldWindow to refresh in order to make these changes visible.
                 }
             });
             cb.setAlignmentX(JComponent.LEFT_ALIGNMENT);
@@ -332,7 +332,7 @@ public class AllPointGraphics extends ApplicationTemplate
                         if (r instanceof TacticalGraphic)
                             ((TacticalGraphic) r).setShowHostileIndicator(tf);
                     }
-                    getWwd().redraw(); // Cause the World Window to refresh in order to make these changes visible.
+                    getWwd().redraw(); // Cause the WorldWindow to refresh in order to make these changes visible.
                 }
             });
             cb.setAlignmentX(JComponent.LEFT_ALIGNMENT);
@@ -352,7 +352,7 @@ public class AllPointGraphics extends ApplicationTemplate
                         if (r instanceof TacticalGraphic)
                             ((TacticalGraphic) r).setShowLocation(tf);
                     }
-                    getWwd().redraw(); // Cause the World Window to refresh in order to make these changes visible.
+                    getWwd().redraw(); // Cause the WorldWindow to refresh in order to make these changes visible.
                 }
             });
             cb.setAlignmentX(JComponent.LEFT_ALIGNMENT);
@@ -373,7 +373,7 @@ public class AllPointGraphics extends ApplicationTemplate
                         if (r instanceof MilStd2525TacticalGraphic)
                             ((MilStd2525TacticalGraphic) r).setStatus(status);
                     }
-                    getWwd().redraw(); // Cause the World Window to refresh in order to make these changes visible.
+                    getWwd().redraw(); // Cause the WorldWindow to refresh in order to make these changes visible.
                 }
             });
             cb.setAlignmentX(JComponent.LEFT_ALIGNMENT);
@@ -390,6 +390,6 @@ public class AllPointGraphics extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_LONGITUDE, -118.4961);
         Configuration.setValue(AVKey.INITIAL_ALTITUDE, 20000);
 
-        ApplicationTemplate.start("World Wind MIL-STD2525 Tactical Point Graphics", AppFrame.class);
+        ApplicationTemplate.start("WorldWind MIL-STD2525 Tactical Point Graphics", AppFrame.class);
     }
 }

--- a/testFunctional/gov/nasa/worldwind/symbology/milstd2525/AllTacticalSymbols.java
+++ b/testFunctional/gov/nasa/worldwind/symbology/milstd2525/AllTacticalSymbols.java
@@ -35,7 +35,7 @@ public class AllTacticalSymbols extends ApplicationTemplate
             this.addSymbols();
             this.addSymbolControls();
 
-            // Size the World Window to provide enough screen space for the symbols and center the World Window on the
+            // Size the WorldWindow to provide enough screen space for the symbols and center the WorldWindow on the
             // screen.
             Dimension size = new Dimension(1800, 1000);
             this.setPreferredSize(size);
@@ -80,7 +80,7 @@ public class AllTacticalSymbols extends ApplicationTemplate
                 lon = startLon;
             }
 
-            // Add the symbol layer to the World Wind model.
+            // Add the symbol layer to the WorldWind model.
             this.getWwd().getModel().getLayers().add(layer);
         }
 
@@ -121,7 +121,7 @@ public class AllTacticalSymbols extends ApplicationTemplate
                         {
                             if (r instanceof TacticalSymbol)
                                 ((MilStd2525TacticalSymbol) r).setShowFrame(tf);
-                            getWwd().redraw(); // Cause the World Window to refresh in order to make these changes visible.
+                            getWwd().redraw(); // Cause the WorldWindow to refresh in order to make these changes visible.
                         }
                     }
                 }
@@ -147,7 +147,7 @@ public class AllTacticalSymbols extends ApplicationTemplate
                         {
                             if (r instanceof TacticalSymbol)
                                 ((MilStd2525TacticalSymbol) r).setShowFill(tf);
-                            getWwd().redraw(); // Cause the World Window to refresh in order to make these changes visible.
+                            getWwd().redraw(); // Cause the WorldWindow to refresh in order to make these changes visible.
                         }
                     }
                 }
@@ -173,7 +173,7 @@ public class AllTacticalSymbols extends ApplicationTemplate
                         {
                             if (r instanceof TacticalSymbol)
                                 ((MilStd2525TacticalSymbol) r).setShowIcon(tf);
-                            getWwd().redraw(); // Cause the World Window to refresh in order to make these changes visible.
+                            getWwd().redraw(); // Cause the WorldWindow to refresh in order to make these changes visible.
                         }
                     }
                 }
@@ -200,7 +200,7 @@ public class AllTacticalSymbols extends ApplicationTemplate
                         {
                             if (r instanceof TacticalSymbol)
                                 ((MilStd2525TacticalSymbol) r).setStatus(status);
-                            getWwd().redraw(); // Cause the World Window to refresh in order to make these changes visible.
+                            getWwd().redraw(); // Cause the WorldWindow to refresh in order to make these changes visible.
                         }
                     }
                 }
@@ -219,7 +219,7 @@ public class AllTacticalSymbols extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_LONGITUDE, -119.85);
         Configuration.setValue(AVKey.INITIAL_ALTITUDE, 77000);
 
-        start("World Wind All MIL-STD-2525 Tactical Symbols", AppFrame.class);
+        start("WorldWind All MIL-STD-2525 Tactical Symbols", AppFrame.class);
     }
 
     protected static List<String> standardIdentities = Arrays.asList(

--- a/testFunctional/gov/nasa/worldwind/symbology/milstd2525/Frames.java
+++ b/testFunctional/gov/nasa/worldwind/symbology/milstd2525/Frames.java
@@ -31,7 +31,7 @@ public class Frames extends ApplicationTemplate
 
             this.addFrameTypeSymbols();
 
-            // Size the World Window to provide enough screen space for the symbols and center the World Window on the
+            // Size the WorldWindow to provide enough screen space for the symbols and center the WorldWindow on the
             // screen.
             Dimension size = new Dimension(1800, 1000);
             this.setPreferredSize(size);
@@ -44,14 +44,14 @@ public class Frames extends ApplicationTemplate
             RenderableLayer layer = new RenderableLayer();
             layer.setName("Standard Frame Types");
             this.addFrameTypeSymbols(SymbologyConstants.STATUS_PRESENT, layer);
-            // Add the symbol layer to the World Wind model.
+            // Add the symbol layer to the WorldWind model.
             this.getWwd().getModel().getLayers().add(layer);
 
             layer = new RenderableLayer();
             layer.setName("Standard Frame Types (Anticipated)");
             layer.setEnabled(false);
             this.addFrameTypeSymbols(SymbologyConstants.STATUS_ANTICIPATED, layer);
-            // Add the symbol layer to the World Wind model.
+            // Add the symbol layer to the WorldWind model.
             this.getWwd().getModel().getLayers().add(layer);
         }
 
@@ -245,6 +245,6 @@ public class Frames extends ApplicationTemplate
         Configuration.setValue(AVKey.INITIAL_LONGITUDE, -120);
         Configuration.setValue(AVKey.INITIAL_ALTITUDE, 100000);
 
-        ApplicationTemplate.start("World Wind MIL-STD-2525 Tactical Symbol Frame Types", AppFrame.class);
+        ApplicationTemplate.start("WorldWind MIL-STD-2525 Tactical Symbol Frame Types", AppFrame.class);
     }
 }

--- a/webstart/AirspaceBuilder.jnlp
+++ b/webstart/AirspaceBuilder.jnlp
@@ -8,28 +8,28 @@
 <jnlp spec="1.0+" codebase="" href="AirspaceBuilder.jnlp">
 
     <!--
-        Provides a description of this World Wind demo application.
+        Provides a description of this WorldWind demo application.
     -->
     <information>
-        <title>World Wind Airspace Builder</title>
+        <title>WorldWind Airspace Builder</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the this World Wind demo application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the this WorldWind demo application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/Airspaces.jnlp
+++ b/webstart/Airspaces.jnlp
@@ -8,28 +8,28 @@
 <jnlp spec="1.0+" codebase="" href="Airspaces.jnlp">
 
     <!--
-        Provides a description of this World Wind demo application.
+        Provides a description of this WorldWind demo application.
     -->
     <information>
-        <title>World Wind Airspaces</title>
+        <title>WorldWind Airspaces</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the this World Wind demo application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the this WorldWind demo application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/AnaglyphStereo.jnlp
+++ b/webstart/AnaglyphStereo.jnlp
@@ -8,28 +8,28 @@
 <jnlp spec="1.0+" codebase="" href="AnaglyphStereo.jnlp">
 
     <!--
-        Provides a description of this World Wind demo application.
+        Provides a description of this WorldWind demo application.
     -->
     <information>
-        <title>World Wind Anaglyph Stereo</title>
+        <title>WorldWind Anaglyph Stereo</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the this World Wind demo application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the this WorldWind demo application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/AnalyticSurface.jnlp
+++ b/webstart/AnalyticSurface.jnlp
@@ -8,30 +8,30 @@
 <jnlp spec="1.0+" codebase="" href="AnalyticSurface.jnlp">
 
     <!--
-        Provides a description of this World Wind demo application.
+        Provides a description of this WorldWind demo application.
     -->
     <information>
-        <title>World Wind Analytic Surface</title>
+        <title>WorldWind Analytic Surface</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the this World Wind demo application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the this WorldWind demo application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
-        * World Wind GDAL Java Web Start component. Adding this component enables World Wind's GDAL data import
+        * WorldWind GDAL Java Web Start component. Adding this component enables WorldWind's GDAL data import
           capability.
     -->
     <resources>

--- a/webstart/AnnotationControls.jnlp
+++ b/webstart/AnnotationControls.jnlp
@@ -8,28 +8,28 @@
 <jnlp spec="1.0+" codebase="" href="AnnotationControls.jnlp">
 
     <!--
-        Provides a description of this World Wind demo application.
+        Provides a description of this WorldWind demo application.
     -->
     <information>
-        <title>World Wind Annotation Controls</title>
+        <title>WorldWind Annotation Controls</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the this World Wind demo application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the this WorldWind demo application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/Annotations.jnlp
+++ b/webstart/Annotations.jnlp
@@ -8,28 +8,28 @@
 <jnlp spec="1.0+" codebase="" href="Annotations.jnlp">
 
     <!--
-        Provides a description of this World Wind demo application.
+        Provides a description of this WorldWind demo application.
     -->
     <information>
-        <title>World Wind Annotations</title>
+        <title>WorldWind Annotations</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the this World Wind demo application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the this WorldWind demo application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/ApplicationTemplate.jnlp
+++ b/webstart/ApplicationTemplate.jnlp
@@ -8,28 +8,28 @@
 <jnlp spec="1.0+" codebase="" href="ApplicationTemplate.jnlp">
 
     <!--
-        Provides a description of this World Wind demo application.
+        Provides a description of this WorldWind demo application.
     -->
     <information>
-        <title>World Wind Application</title>
+        <title>WorldWind Application</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the this World Wind demo application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the this WorldWind demo application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/ExportImageOrElevations.jnlp
+++ b/webstart/ExportImageOrElevations.jnlp
@@ -8,28 +8,28 @@
 <jnlp spec="1.0+" codebase="" href="ExportImageOrElevations.jnlp">
 
     <!--
-        Provides a description of this World Wind demo application.
+        Provides a description of this WorldWind demo application.
     -->
     <information>
-        <title>World Wind Exporting Surface Imagery and Elevations</title>
+        <title>WorldWind Exporting Surface Imagery and Elevations</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the this World Wind demo application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the this WorldWind demo application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/ExtrudedShapes.jnlp
+++ b/webstart/ExtrudedShapes.jnlp
@@ -8,28 +8,28 @@
 <jnlp spec="1.0+" codebase="" href="ExtrudedShapes.jnlp">
 
     <!--
-        Provides a description of this World Wind demo application.
+        Provides a description of this WorldWind demo application.
     -->
     <information>
-        <title>World Wind Extruded Polygons on Ground</title>
+        <title>WorldWind Extruded Polygons on Ground</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the this World Wind demo application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the this WorldWind demo application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/FlatWorld.jnlp
+++ b/webstart/FlatWorld.jnlp
@@ -8,28 +8,28 @@
 <jnlp spec="1.0+" codebase="" href="FlatWorld.jnlp">
 
     <!--
-        Provides a description of this World Wind demo application.
+        Provides a description of this WorldWind demo application.
     -->
     <information>
-        <title>World Wind Flat World</title>
+        <title>WorldWind Flat World</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the this World Wind demo application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the this WorldWind demo application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/FlatWorldEarthquakes.jnlp
+++ b/webstart/FlatWorldEarthquakes.jnlp
@@ -8,28 +8,28 @@
 <jnlp spec="1.0+" codebase="" href="FlatWorldEarthquakes.jnlp">
 
     <!--
-        Provides a description of this World Wind demo application.
+        Provides a description of this WorldWind demo application.
     -->
     <information>
-        <title>World Wind USGS Earthquakes M 2.5+ - 7 days</title>
+        <title>WorldWind USGS Earthquakes M 2.5+ - 7 days</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the this World Wind demo application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the this WorldWind demo application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/InstallImageryAndElevationsDemo.jnlp
+++ b/webstart/InstallImageryAndElevationsDemo.jnlp
@@ -8,31 +8,31 @@
 <jnlp spec="1.0+" codebase="" href="InstallImageryAndElevationsDemo.jnlp">
 
     <!--
-        Provides a description of this World Wind demo application.
+        Provides a description of this WorldWind demo application.
     -->
     <information>
-        <title>World Wind Imagery and Elevation Installation</title>
+        <title>WorldWind Imagery and Elevation Installation</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the this World Wind demo application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind
+        Specifies the resources required by the this WorldWind demo application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind
           SDK requires at least 1024 MB of heap space, and we specify 1024 in order to enable import of large imagery
           and elevation files. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
-        * World Wind GDAL Java Web Start component. Adding this component enables World Wind's GDAL data import
+        * WorldWind GDAL Java Web Start component. Adding this component enables WorldWind's GDAL data import
           capability.
     -->
     <resources>

--- a/webstart/JavaWebStartTemplate.jnlp
+++ b/webstart/JavaWebStartTemplate.jnlp
@@ -6,7 +6,7 @@
   -->
 
 <!--
-  ~ Example configuration file for a Java Web Start application that uses the World Wind Java SDK. Replace everything in
+  ~ Example configuration file for a Java Web Start application that uses the WorldWind Java SDK. Replace everything in
   ~ all caps below with your own information.
   -->
 <jnlp spec="1.0+" codebase="" href="JavaWebStartTemplate.jnlp">
@@ -24,10 +24,10 @@
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA. The
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA. The
         application's JAR files must also be signed with a digital signature. The application's signature may be
-        different from the World Wind signature, provided that the World Wind JAR files are loaded by extension as shown
+        different from the WorldWind signature, provided that the WorldWind JAR files are loaded by extension as shown
         below.
     -->
     <security>
@@ -35,11 +35,11 @@
     </security>
 
     <!--
-        Specifies the resources required by the World Wind SDK core library:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the WorldWind SDK core library:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
         * Application Jar file. This downloads and adds the application's JAR file to the class path at runtime.
-        * World Wind core Java Web Start component. This downloads and adds the World Wind SDK core JAR file and its
+        * WorldWind core Java Web Start component. This downloads and adds the WorldWind SDK core JAR file and its
           dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/KMLViewer.jnlp
+++ b/webstart/KMLViewer.jnlp
@@ -8,28 +8,28 @@
 <jnlp spec="1.0+" codebase="" href="KMLViewer.jnlp">
 
     <!--
-        Provides a description of this World Wind demo application.
+        Provides a description of this WorldWind demo application.
     -->
     <information>
-        <title>World Wind KML Viewer</title>
+        <title>WorldWind KML Viewer</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the this World Wind demo application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the this WorldWind demo application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/KeepingObjectsInView.jnlp
+++ b/webstart/KeepingObjectsInView.jnlp
@@ -8,7 +8,7 @@
 <jnlp spec="1.0+" codebase="" href="KeepingObjectsInView.jnlp">
 
     <!--
-        Provides a description of this World Wind demo application.
+        Provides a description of this WorldWind demo application.
     -->
     <information>
         <title>Keeping Objects In View</title>
@@ -18,18 +18,18 @@
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the this World Wind demo application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the this WorldWind demo application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/LineBuilder.jnlp
+++ b/webstart/LineBuilder.jnlp
@@ -8,28 +8,28 @@
 <jnlp spec="1.0+" codebase="" href="LineBuilder.jnlp">
 
     <!--
-        Provides a description of this World Wind demo application.
+        Provides a description of this WorldWind demo application.
     -->
     <information>
-        <title>World Wind Line Builder</title>
+        <title>WorldWind Line Builder</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the this World Wind demo application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the this WorldWind demo application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/MGRSGraticule.jnlp
+++ b/webstart/MGRSGraticule.jnlp
@@ -8,28 +8,28 @@
 <jnlp spec="1.0+" codebase="" href="MGRSGraticule.jnlp">
 
     <!--
-        Provides a description of this World Wind demo application.
+        Provides a description of this WorldWind demo application.
     -->
     <information>
-        <title>World Wind UTM/MGRS Graticule</title>
+        <title>WorldWind UTM/MGRS Graticule</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the this World Wind demo application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the this WorldWind demo application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/MultiWindowViewVolume.jnlp
+++ b/webstart/MultiWindowViewVolume.jnlp
@@ -8,28 +8,28 @@
 <jnlp spec="1.0+" codebase="" href="MultiWindowViewVolume.jnlp">
 
     <!--
-        Provides a description of this World Wind demo application.
+        Provides a description of this WorldWind demo application.
     -->
     <information>
-        <title>World Wind Multip Window View Volume</title>
+        <title>WorldWind Multip Window View Volume</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the this World Wind demo application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the this WorldWind demo application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/RigidShapes.jnlp
+++ b/webstart/RigidShapes.jnlp
@@ -8,28 +8,28 @@
 <jnlp spec="1.0+" codebase="" href="RigidShapes.jnlp">
 
     <!--
-        Provides a description of this World Wind demo application.
+        Provides a description of this WorldWind demo application.
     -->
     <information>
-        <title>World Wind Rigid Shapes</title>
+        <title>WorldWind Rigid Shapes</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the this World Wind demo application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the this WorldWind demo application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/SARApp.jnlp
+++ b/webstart/SARApp.jnlp
@@ -8,28 +8,28 @@
 <jnlp spec="1.0+" codebase="" href="SARApp.jnlp">
 
     <!--
-        Provides a description of the World Wind Search and Rescue prototype application.
+        Provides a description of the WorldWind Search and Rescue prototype application.
     -->
     <information>
-        <title>World Wind Search and Rescue Prototype</title>
+        <title>WorldWind Search and Rescue Prototype</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the World Wind Search and Rescue prototype:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the WorldWind Search and Rescue prototype:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/ScankortDenmark.jnlp
+++ b/webstart/ScankortDenmark.jnlp
@@ -8,7 +8,7 @@
 <jnlp spec="1.0+" codebase="" href="ScankortDenmark.jnlp">
 
     <!--
-        Provides a description of this World Wind demo application.
+        Provides a description of this WorldWind demo application.
     -->
     <information>
         <title>Scankort Denmark Data</title>
@@ -18,18 +18,18 @@
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the this World Wind demo application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the this WorldWind demo application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/SurfaceShapes.jnlp
+++ b/webstart/SurfaceShapes.jnlp
@@ -8,28 +8,28 @@
 <jnlp spec="1.0+" codebase="" href="SurfaceShapes.jnlp">
 
     <!--
-        Provides a description of this World Wind demo application.
+        Provides a description of this WorldWind demo application.
     -->
     <information>
-        <title>World Wind Surface Shapes</title>
+        <title>WorldWind Surface Shapes</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the this World Wind demo application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the this WorldWind demo application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/TacticalGraphics.jnlp
+++ b/webstart/TacticalGraphics.jnlp
@@ -8,28 +8,28 @@
 <jnlp spec="1.0+" codebase="" href="TacticalGraphics.jnlp">
 
     <!--
-        Provides a description of this World Wind demo application.
+        Provides a description of this WorldWind demo application.
     -->
     <information>
-        <title>World Wind Tactical Graphics</title>
+        <title>WorldWind Tactical Graphics</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the this World Wind demo application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the this WorldWind demo application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/TacticalSymbols.jnlp
+++ b/webstart/TacticalSymbols.jnlp
@@ -8,28 +8,28 @@
 <jnlp spec="1.0+" codebase="" href="TacticalSymbols.jnlp">
 
     <!--
-        Provides a description of this World Wind demo application.
+        Provides a description of this WorldWind demo application.
     -->
     <information>
-        <title>World Wind Tactical Symbols</title>
+        <title>WorldWind Tactical Symbols</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the this World Wind demo application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the this WorldWind demo application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/TerrainProfiler.jnlp
+++ b/webstart/TerrainProfiler.jnlp
@@ -8,28 +8,28 @@
 <jnlp spec="1.0+" codebase="" href="TerrainProfiler.jnlp">
 
     <!--
-        Provides a description of this World Wind demo application.
+        Provides a description of this WorldWind demo application.
     -->
     <information>
-        <title>World Wind Terrain Profiler</title>
+        <title>WorldWind Terrain Profiler</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the this World Wind demo application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the this WorldWind demo application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/VideoOnTerrain.jnlp
+++ b/webstart/VideoOnTerrain.jnlp
@@ -8,28 +8,28 @@
 <jnlp spec="1.0+" codebase="" href="VideoOnTerrain.jnlp">
 
     <!--
-        Provides a description of this World Wind demo application.
+        Provides a description of this WorldWind demo application.
     -->
     <information>
-        <title>World Wind Video on Terrain</title>
+        <title>WorldWind Video on Terrain</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the this World Wind demo application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the this WorldWind demo application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/WMSLayerManager.jnlp
+++ b/webstart/WMSLayerManager.jnlp
@@ -8,28 +8,28 @@
 <jnlp spec="1.0+" codebase="" href="WMSLayerManager.jnlp">
 
     <!--
-        Provides a description of this World Wind demo application.
+        Provides a description of this WorldWind demo application.
     -->
     <information>
-        <title>World Wind WMS Layers</title>
+        <title>WorldWind WMS Layers</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the this World Wind demo application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the this WorldWind demo application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/WebBrowserBalloons.jnlp
+++ b/webstart/WebBrowserBalloons.jnlp
@@ -8,28 +8,28 @@
 <jnlp spec="1.0+" codebase="" href="WebBrowserBalloons.jnlp">
 
     <!--
-        Provides a description of this World Wind demo application.
+        Provides a description of this WorldWind demo application.
     -->
     <information>
-        <title>World Wind Web Browser Balloons</title>
+        <title>WorldWind Web Browser Balloons</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the this World Wind demo application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the this WorldWind demo application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/WorldWindDiagnostics.jnlp
+++ b/webstart/WorldWindDiagnostics.jnlp
@@ -8,28 +8,28 @@
 <jnlp spec="1.0+" codebase="" href="WorldWindDiagnostics.jnlp">
 
     <!--
-        Provides a description of the World Wind Diagnostics application.
+        Provides a description of the WorldWind Diagnostics application.
     -->
     <information>
-        <title>World Wind Diagnostic Program</title>
+        <title>WorldWind Diagnostic Program</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the World Wind Diagnostics application:
-        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The World Wind SDK
+        Specifies the resources required by the WorldWind Diagnostics application:
+        * Java Runtime Environment version 1.6 or newer, with a maximum heap size of at least 1024 MB. The WorldWind SDK
           requires at least 1024 MB of heap space. This heap size must be specified in the application's Web Start file.
-        * World Wind extensions Java Web Start component. This downloads and adds the World Wind SDK extensions JAR file
+        * WorldWind extensions Java Web Start component. This downloads and adds the WorldWind SDK extensions JAR file
           and its dependencies ot the class path at runtime.
     -->
     <resources>

--- a/webstart/gdal.jnlp
+++ b/webstart/gdal.jnlp
@@ -8,28 +8,28 @@
 <jnlp  spec="1.0+" codebase="" href="gdal.jnlp">
 
     <!--
-        Provides a description of the World Wind GDAL library.
+        Provides a description of the WorldWind GDAL library.
     -->
     <information>
-        <title>NASA World Wind Java GDAL</title>
+        <title>NASA WorldWind Java GDAL</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind GDAL library requires access to the local filesystem.
-        All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind GDAL library requires access to the local filesystem.
+        All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the World Wind GDAL library:
-        * World Wind GDAL JAR file.
-        * World Wind GDAL data JAR file.
-        * World Wind GDAL native libraries.
+        Specifies the resources required by the WorldWind GDAL library:
+        * WorldWind GDAL JAR file.
+        * WorldWind GDAL data JAR file.
+        * WorldWind GDAL native libraries.
     -->
     <resources>
         <jar href="gdal.jar"/>

--- a/webstart/gluegen-rt.jnlp
+++ b/webstart/gluegen-rt.jnlp
@@ -25,7 +25,7 @@
 
     <!--
         Requests a trusted application environment. The GlueGen library requires access to the local filesystem. The
-        GlueGen JAR files hosted as part of the World Wind Java SDK are signed with a digital signature associated with
+        GlueGen JAR files hosted as part of the WorldWind Java SDK are signed with a digital signature associated with
         NASA.
     -->
     <security>

--- a/webstart/jogl-all.jnlp
+++ b/webstart/jogl-all.jnlp
@@ -23,7 +23,7 @@
 
     <!--
         Requests a trusted application environment. The JOGL library requires access to the local filesystem. The JOGL
-        JAR files hosted as part of the World Wind Java SDK are signed with a digital signature associated with NASA.
+        JAR files hosted as part of the WorldWind Java SDK are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>

--- a/webstart/worldwind.jnlp
+++ b/webstart/worldwind.jnlp
@@ -8,33 +8,33 @@
 <jnlp spec="1.0+" codebase="" href="worldwind.jnlp">
 
     <!--
-        Provides a description of the World Wind SDK core library.
+        Provides a description of the WorldWind SDK core library.
     -->
     <information>
-        <title>NASA World Wind Java</title>
+        <title>NASA WorldWind Java</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK core library requires access to the network and
-        the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK core library requires access to the network and
+        the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the World Wind SDK core library:
-        * World Wind core JAR file.
-        * World Wind GDAL JAR file. World Wind must include the GDAL JAR file on its class path, even when the GDAL
+        Specifies the resources required by the WorldWind SDK core library:
+        * WorldWind core JAR file.
+        * WorldWind GDAL JAR file. WorldWind must include the GDAL JAR file on its class path, even when the GDAL
           native libraries are not used. We include the GDAL JAR file at the GDAL webstart site to avoid a version
           conflict should the application choose to include the GDAL Web Start component.
-        * JOGL version 2.0 Web Start component. World Wind depends on the JOGL library to communicate with the platform
+        * JOGL version 2.0 Web Start component. WorldWind depends on the JOGL library to communicate with the platform
           native OpenGL libraries.
         * WebView native library JAR archives for Mac OS X, Windows 32-bit and Windows 64-bit. The WebView native
-          libraries are required by implementations of the World Wind BrowserBalloon class.
+          libraries are required by implementations of the WorldWind BrowserBalloon class.
         * Disable the use of DirectDraw by Java2D on Windows. This is necessary for correct operation of JOGL on Windows
           and is accomplished by setting the sun.java2d.noddraw property to true. See the JOGL Userguide for details:
           http://jogamp.org/jogl/doc/userguide/

--- a/webstart/worldwindx.jnlp
+++ b/webstart/worldwindx.jnlp
@@ -8,27 +8,27 @@
 <jnlp spec="1.0+" codebase="" href="worldwindx.jnlp">
 
     <!--
-        Provides a description of the World Wind SDK extensions library.
+        Provides a description of the WorldWind SDK extensions library.
     -->
     <information>
-        <title>NASA World Wind Java Extensions</title>
+        <title>NASA WorldWind Java Extensions</title>
         <vendor>NASA</vendor>
         <homepage href="https://worldwind.arc.nasa.gov"/>
         <offline-allowed/>
     </information>
 
     <!--
-        Requests a trusted application environment. The World Wind SDK extensions library requires access to the network
-        and the local filesystem. All World Wind JAR files are signed with a digital signature associated with NASA.
+        Requests a trusted application environment. The WorldWind SDK extensions library requires access to the network
+        and the local filesystem. All WorldWind JAR files are signed with a digital signature associated with NASA.
     -->
     <security>
         <all-permissions/>
     </security>
 
     <!--
-        Specifies the resources required by the World Wind SDK extensions library:
-        * World Wind extensions JAR file.
-        * World Wind core Java Web Start component.
+        Specifies the resources required by the WorldWind SDK extensions library:
+        * WorldWind extensions JAR file.
+        * WorldWind core Java Web Start component.
     -->
     <resources>
         <jar href="worldwindx.jar"/>


### PR DESCRIPTION
### Description of the Change
- All instances of "World Wind" in the source code comments and supporting documentation have been changed to "WorldWind". 

### Why Should This Be In Core?, Benefits
- This pull request is necessary to make "WorldWind" the consistent project name. It is part of a larger epic which updates the documentation in WorldWind Java's repository. 

Closes [#121](https://github.com/NASAWorldWind/WorldWindJava/issues/121), closes [#125](https://github.com/NASAWorldWind/WorldWindJava/issues/125).

### Potential Drawbacks
- Many files were modified, which may require more time spent on the review process.  

### Applicable Issues