### PR TITLE
correct test for DTED file extension

### DIFF
--- a/src/gov/nasa/worldwindx/examples/dataimport/InstallDTED.java
+++ b/src/gov/nasa/worldwindx/examples/dataimport/InstallDTED.java
@@ -148,9 +148,9 @@ public class InstallDTED extends ApplicationTemplate
                 {
                     this.findDTEDFiles(file, files);
                 }
-                else if (file.getName().endsWith("dt0")
-                    || file.getName().endsWith("dt1")
-                    || file.getName().endsWith("dt2"))
+                else if (file.getName().toLowerCase().endsWith("dt0")
+                    || file.getName().toLowerCase().endsWith("dt1")
+                    || file.getName().toLowerCase().endsWith("dt2"))
                 {
                     files.add(file);
                 }


### PR DESCRIPTION
**Note:** Filling out this template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the
maintainer's discretion.

### Description of the Change
Use a case insensitive comparison for the DTED file extensions

### Why Should This Be In Core?
I have example data from 3rd parties that use upper case file extensions, e.g., .DT2

### Benefits

### Potential Drawbacks

### Applicable Issues