### PR TITLE
Replace broken NASA OSM mapcache with the OSMMapnickLayer at 50% opacity

### DIFF
--- a/src/config/worldwind.layers.xml
+++ b/src/config/worldwind.layers.xml
@@ -30,10 +30,10 @@
     <Layer href="config/Earth/USGSTopoLowResLayer.xml" actuate="onRequest"/>
     <Layer href="config/Earth/USGSTopoMedResLayer.xml" actuate="onRequest"/>
     <Layer href="config/Earth/USGSTopoHighResLayer.xml" actuate="onRequest"/>
-    <!--<Layer className="gov.nasa.worldwind.layers.Earth.OSMMapnikLayer" actuate="onRequest"/>-->
+    <Layer className="gov.nasa.worldwind.layers.Earth.OSMMapnikLayer" actuate="onRequest"/>
     <!--<Layer className="gov.nasa.worldwind.layers.Earth.OSMCycleMapLayer" actuate="onRequest"/>-->
     <Layer className="gov.nasa.worldwind.layers.Earth.CountryBoundariesLayer" actuate="onRequest"/>
-    <Layer href="config/Earth/OpenStreetMap.xml" actuate="onRequest"/>
+    <!--<Layer href="config/Earth/OpenStreetMap.xml" actuate="onRequest"/>-->
     <!--<Layer href="config/Earth/WorldBordersShapefile.xml" actuate="onRequest"/>-->
     <Layer href="config/Earth/EarthAtNightLayer.xml" actuate="onRequest"/>
     <Layer className="gov.nasa.worldwind.layers.Earth.NASAWFSPlaceNameLayer"/>

--- a/src/gov/nasa/worldwind/layers/Earth/OSMMapnikLayer.java
+++ b/src/gov/nasa/worldwind/layers/Earth/OSMMapnikLayer.java
@@ -17,9 +17,12 @@ import java.net.*;
  */
 public class OSMMapnikLayer extends BasicMercatorTiledImageLayer
 {
+    static final double DEFAULT_OPACITY = 0.5d;
+
     public OSMMapnikLayer()
     {
         super(makeLevels());
+        setOpacity(DEFAULT_OPACITY);
     }
 
     private static LevelSet makeLevels()


### PR DESCRIPTION
### Description of the Change

1. OSMMapnickLayer default to 50% opacity so it is useful as an overlay
2. Swap broken OSM Layer Earth/OpenStreetMap.xml with OSMMapnikLayer in config/worldwind.layers.xml

### Why Should This Be In Core?
The default OSM layer is currently broken, creating a problem for all the demo/example apps.
Should not negatively impact any applications that use WWJ SDK.

### Benefits
Minor change restores presense of a working OSM layer to all the demo/example apps.

### Potential Drawbacks
OSMMapnikLayer hits a.tile.openstreetmap.org directly, including it by default with increase load on openstreetmap.org servers.
Applications that have the broken NASA OSM tileset cached locally and rely on the content of the default worldwind.layers.xml pointing to the Earth/OpenStreetMap.xml will no longer use that cached tileset.  The cached NASA OSM tileset cannot be easily reused by OSMMapnikLayer because of different projections.  The workaround for such applications is to retain the unchanged version of config/worldwind.layers.xml

### Applicable Issues

#138
