### PR TITLE
Fix broken NASA logo reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://worldwind.arc.nasa.gov/css/images/nasa-logo.svg" height="100"/>
+<img src="https://worldwind.arc.nasa.gov/img/nasa-logo.svg" height="100"/>
 
 # WorldWind Java
 


### PR DESCRIPTION
Closes [101](https://github.com/NASAWorldWind/NASAWorldWind.github.io/issues/101) in NASAWorldWind.github.io repo. 

Corrected the path to NASA logo in the README file. It was incorrect because our site infrastructure has changed since migrating to Hugo