### PR TITLE
Publish API documentation to gh-pages on every push to develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,13 @@ script:
 
 # Deploy build artifacts. Travis does not invoke this step for pull request builds
 deploy:
+  # Publish API documentation to GitHub Pages
+  - provider: pages
+    github_token: $GITHUB_API_KEY
+    local_dir: build/doc/javadoc
+    skip_cleanup: true
+    on:
+      branch: develop
   # Create CHANGELOG.md in the current directory
   - provider: script
     script: ./travis/changelog.sh >> CHANGELOG.md


### PR DESCRIPTION
### Description of the Change

Publish the WorldWindJava API documentation to the built-in GitHub pages site after every push to develop. The resultant documentation is immediately available online and always up-to-date. The WorldWind website links to this documentation from the Java documentation page.

https://NASAWorldWind.github.io/WorldWindJava

### Why Should This Be In Core?

See description.

### Benefits

See description.

### Potential Drawbacks

None.

### Applicable Issues

Closes #142 