### PR TITLE
Partial fix of #195

### DIFF
--- a/src/gov/nasa/worldwind/WorldWindowGLAutoDrawable.java
+++ b/src/gov/nasa/worldwind/WorldWindowGLAutoDrawable.java
@@ -495,7 +495,11 @@ public class WorldWindowGLAutoDrawable extends WorldWindowImpl implements WorldW
      */
     public void reshape(GLAutoDrawable glAutoDrawable, int x, int y, int w, int h)
     {
-        // This is apparently necessary to enable the WWJ canvas to resize correctly with JSplitPane.
+        GL2 gl = this.drawable.getGL().getGL2(); // change this as needed
+        double dpiScalingFactor = (double) (Toolkit.getDefaultToolkit().getScreenResolution() / 96.0);
+        w = (int) (w * dpiScalingFactor);
+        h = (int) (h * dpiScalingFactor);
+        gl.glViewport(0, 0, w, h);
         ((Component) glAutoDrawable).setMinimumSize(new Dimension(0, 0));
     }
 

--- a/src/gov/nasa/worldwind/awt/WorldWindowGLCanvas.java
+++ b/src/gov/nasa/worldwind/awt/WorldWindowGLCanvas.java
@@ -39,6 +39,8 @@ import gov.nasa.worldwind.util.*;
 import com.jogamp.opengl.*;
 import com.jogamp.opengl.awt.GLCanvas;
 import java.awt.*;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseWheelEvent;
 import java.beans.*;
 import java.util.*;
 
@@ -486,5 +488,35 @@ public class WorldWindowGLCanvas extends GLCanvas implements WorldWindow, Proper
     public Collection<PerformanceStatistic> getPerFrameStatistics()
     {
         return this.wwd.getPerFrameStatistics();
+    }
+    
+    @Override
+    protected void processMouseEvent(MouseEvent e) {
+        double dpiScalingFactor = (double) (Toolkit.getDefaultToolkit().getScreenResolution() / 96.0);
+        int x = (int) (e.getPoint().x * dpiScalingFactor);
+        int y = (int) (e.getPoint().y * dpiScalingFactor);
+        MouseEvent scaledEvent = new MouseEvent((Component)e.getSource(), e.getID(),
+                e.getWhen(), e.getModifiersEx(), x, y, e.getXOnScreen(), e.getYOnScreen(), e.getClickCount(), false,e.getButton());
+        super.processMouseEvent(scaledEvent);
+    }
+    
+    @Override
+    protected void processMouseMotionEvent(MouseEvent e) {
+        double dpiScalingFactor = (double) (Toolkit.getDefaultToolkit().getScreenResolution() / 96.0);
+        int x = (int) (e.getPoint().x * dpiScalingFactor);
+        int y = (int) (e.getPoint().y * dpiScalingFactor);
+        MouseEvent scaledEvent = new MouseEvent((Component) e.getSource(), e.getID(), e.getWhen(), e.getModifiersEx(),
+                x, y, e.getXOnScreen(), e.getYOnScreen(), e.getClickCount(), false, e.getButton());
+        super.processMouseMotionEvent(scaledEvent);
+    }
+    
+    @Override
+    protected void processMouseWheelEvent(MouseWheelEvent e) {
+        double dpiScalingFactor = (double) (Toolkit.getDefaultToolkit().getScreenResolution() / 96.0);;
+        int x = (int) (e.getPoint().x * dpiScalingFactor);
+        int y = (int) (e.getPoint().y * dpiScalingFactor);
+        MouseWheelEvent scaledEvent = new MouseWheelEvent((Component) e.getSource(),
+                e.getID(), e.getWhen(), e.getModifiersEx(), x, y, e.getXOnScreen(), e.getYOnScreen(), e.getClickCount(), false, e.getScrollType(),e.getScrollAmount(),e.getWheelRotation());
+        super.processMouseWheelEvent(scaledEvent);
     }
 }


### PR DESCRIPTION
### Description of the Change
Partial fix of issue #195 . Allows to resize the World Window according to Windows's scaling factor.

### Why Should This Be In Core?
Because issue #195 is a problematic bug.

### Benefits
It partially fixes issue #195. The fix is partial because it works only on program startup. If Windows's scaling factor is changed during execution issue #195 still reproduces.

### Potential Drawbacks
Not that I know of.

### Applicable Issues
#195 

### Comments
Thanks to @thwe74 for this solution.