### PR TITLE
Made StatusBar swing timer stoppable

### DIFF
--- a/src/gov/nasa/worldwind/util/StatusBar.java
+++ b/src/gov/nasa/worldwind/util/StatusBar.java
@@ -62,6 +62,7 @@ public class StatusBar extends JPanel implements PositionListener, RenderingList
     protected AtomicBoolean showNetworkStatus = new AtomicBoolean(true);
     protected AtomicBoolean isNetworkAvailable = new AtomicBoolean(true);
     protected Thread netCheckThread;
+    private Timer downloadTimer;
 
     public StatusBar()
     {
@@ -83,7 +84,7 @@ public class StatusBar extends JPanel implements PositionListener, RenderingList
         heartBeat.setHorizontalAlignment(SwingConstants.CENTER);
         heartBeat.setForeground(new java.awt.Color(255, 0, 0, 0));
 
-        Timer downloadTimer = new Timer(100, new ActionListener()
+        downloadTimer = new Timer(100, new ActionListener()
         {
             public void actionPerformed(java.awt.event.ActionEvent actionEvent)
             {
@@ -319,5 +320,10 @@ public class StatusBar extends JPanel implements PositionListener, RenderingList
                     altDisplay.setText(Logging.getMessage("term.Altitude"));
             }
         });
+    }
+    
+    public void stopDownloadTimer()
+    {
+        downloadTimer.stop();
     }
 }


### PR DESCRIPTION
### Description of the Change

In the class gov.nasa.worldwind.util.StatusBar a SwingTimer is created as a local variable in the constructor. This way the timer can never be stopped.

### Why Should This Be In Core?

Every Application which does not rely on System.exit() for its shutdown could have a problem with the timer mentioned above as the AWT Thread won't stop. Usage of System.exit() can be a problem if there are automated system tests executed by tools like the maven-failsafe-plugin, which does not allow for such calls.

### Benefits

The timer can be stopped and applications can do a graceful shutdown.

### Potential Drawbacks

There is the risk that a programmer calls the stop method and wonders why the network status is not updated anymore. It could even be argued that the encapsulation is broken but by using global state like the swing timer facility there is no other practical way to clean this up the way it is currently designed.

### Applicable Issues