### PR TITLE
Removed outdated references to goworldwind.org website

### DIFF
--- a/src/config/worldwind.xml
+++ b/src/config/worldwind.xml
@@ -116,7 +116,7 @@
     <!--<Property name="gov.nasa.worldwind.avkey.UrlProxyType" value="Proxy.Type.Http"/>-->
 
     <!-- Location of icons for MIL-STD-2525C symbol set. This can be a URL to a web server, to a local zip or jar archive.
-See https://worldwind.arc.nasa.gov/java/tutorials/tactical-graphics/ for more information.
+See the "Tactical Symbols" tutorials in https://worldwind.arc.nasa.gov/java/tutorials/ for more information.
 Examples: http://myserver.com/milstd2525/   (web server)
     jar:file:milstd2525-symbols.zip!  (local zip archive)  -->
     <Property name="gov.nasa.worldwind.avkey.MilStd2525IconRetrieverPath"

--- a/src/config/worldwind.xml
+++ b/src/config/worldwind.xml
@@ -116,7 +116,8 @@
     <!--<Property name="gov.nasa.worldwind.avkey.UrlProxyType" value="Proxy.Type.Http"/>-->
 
     <!-- Location of icons for MIL-STD-2525C symbol set. This can be a URL to a web server, to a local zip or jar archive.
-See the "Tactical Symbols" tutorials in https://worldwind.arc.nasa.gov/java/tutorials/ for more information.
+See https://worldwind.arc.nasa.gov/java/tutorials/tactical-symbols/#offline-use for more information on how
+to configure a local symbol repository.
 Examples: http://myserver.com/milstd2525/   (web server)
     jar:file:milstd2525-symbols.zip!  (local zip archive)  -->
     <Property name="gov.nasa.worldwind.avkey.MilStd2525IconRetrieverPath"

--- a/src/config/worldwind.xml
+++ b/src/config/worldwind.xml
@@ -116,8 +116,7 @@
     <!--<Property name="gov.nasa.worldwind.avkey.UrlProxyType" value="Proxy.Type.Http"/>-->
 
     <!-- Location of icons for MIL-STD-2525C symbol set. This can be a URL to a web server, to a local zip or jar archive.
-See https://goworldwind.org/developers-guide/symbology/tactical-symbols/#offline-use for more information on how
-to configure a local symbol repository.
+See https://worldwind.arc.nasa.gov/java/tutorials/tactical-graphics/ for more information.
 Examples: http://myserver.com/milstd2525/   (web server)
     jar:file:milstd2525-symbols.zip!  (local zip archive)  -->
     <Property name="gov.nasa.worldwind.avkey.MilStd2525IconRetrieverPath"

--- a/src/gov/nasa/worldwind/data/package-info.java
+++ b/src/gov/nasa/worldwind/data/package-info.java
@@ -311,7 +311,7 @@
 <h3>Deploying with Java Web Start</h3>
  *
     Instructions for using the WorldWind GDAL libraries with a Java Web Start application are available at
- * <a href="https://goworldwind.org/getting-started/" target="_blank">https://goworldwind.org/getting-started/</a>.
+ * <a href="https://worldwind.arc.nasa.gov/java/get-started/" target="_blank">https://worldwind.arc.nasa.gov/java/get-started/</a>.
  *
  * <!--**************************************************************-->
  * <!--********************  Use Case Examples  *********************-->


### PR DESCRIPTION
### Description of the Change
Two of our .xml project files still have references to the now deprecated goworldwind.org website. This change addresses this, updating the references to current ones.
