### PR TITLE
Fix display of context menu in ContextMenusOnShapes demo.

### DIFF
--- a/src/gov/nasa/worldwind/awt/AWTInputHandler.java
+++ b/src/gov/nasa/worldwind/awt/AWTInputHandler.java
@@ -404,24 +404,26 @@ public class AWTInputHandler extends WWObjectImpl
         if (pickedObjects != null && pickedObjects.getTopPickedObject() != null
             && !pickedObjects.getTopPickedObject().isTerrain())
         {
-            // Something is under the cursor, so it's deemed "selected".
+        	Point awtPt = awtMouseEvent.getPoint();		// AWT screen coordinates
+
+        	// Something is under the cursor, so it's deemed "selected".
             if (MouseEvent.BUTTON1 == mouseEvent.getButton())
             {
                 if (mouseEvent.getClickCount() <= 1)
                 {
                     this.callSelectListeners(new SelectEvent(this.wwd, SelectEvent.LEFT_CLICK,
-                        mouseEvent, pickedObjects));
+                    		awtPt, mouseEvent, pickedObjects));
                 }
                 else
                 {
                     this.callSelectListeners(new SelectEvent(this.wwd, SelectEvent.LEFT_DOUBLE_CLICK,
-                        mouseEvent, pickedObjects));
+                    		awtPt, mouseEvent, pickedObjects));
                 }
             }
             else if (MouseEvent.BUTTON3 == mouseEvent.getButton())
             {
                 this.callSelectListeners(new SelectEvent(this.wwd, SelectEvent.RIGHT_CLICK,
-                    mouseEvent, pickedObjects));
+                		awtPt, mouseEvent, pickedObjects));
             }
 
             this.wwd.getView().firePropertyChange(AVKey.VIEW, null, this.wwd.getView());
@@ -472,16 +474,18 @@ public class AWTInputHandler extends WWObjectImpl
         if (this.objectsAtButtonPress != null && objectsAtButtonPress.getTopPickedObject() != null
             && !this.objectsAtButtonPress.getTopPickedObject().isTerrain())
         {
+        	Point awtPt = awtMouseEvent.getPoint();		// AWT screen coordinates
+
             // Something is under the cursor, so it's deemed "selected".
             if (MouseEvent.BUTTON1 == mouseEvent.getButton())
             {
                 this.callSelectListeners(new SelectEvent(this.wwd, SelectEvent.LEFT_PRESS,
-                    mouseEvent, this.objectsAtButtonPress));
+                		awtPt, mouseEvent, this.objectsAtButtonPress));
             }
             else if (MouseEvent.BUTTON3 == mouseEvent.getButton())
             {
                 this.callSelectListeners(new SelectEvent(this.wwd, SelectEvent.RIGHT_PRESS,
-                    mouseEvent, this.objectsAtButtonPress));
+                		awtPt, mouseEvent, this.objectsAtButtonPress));
             }
 
             // Initiate a repaint.
@@ -600,8 +604,9 @@ public class AWTInputHandler extends WWObjectImpl
                 && !pickedObjects.getTopPickedObject().isTerrain()))
             {
                 this.isDragging = true;
-                DragSelectEvent selectEvent = new DragSelectEvent(this.wwd, SelectEvent.DRAG, mouseEvent, pickedObjects,
-                    prevMousePoint);
+                DragSelectEvent selectEvent = new DragSelectEvent(this.wwd, SelectEvent.DRAG, 
+                									awtMouseEvent.getPoint(), mouseEvent, 
+                									pickedObjects, prevMousePoint);
                 this.callSelectListeners(selectEvent);
 
                 // If no listener consumed the event, then cancel the drag.
@@ -790,7 +795,7 @@ public class AWTInputHandler extends WWObjectImpl
         if (this.isDragging)
         {
             this.callSelectListeners(new DragSelectEvent(this.wwd, SelectEvent.DRAG_END, null,
-                this.objectsAtButtonPress, this.mousePoint));
+                null, this.objectsAtButtonPress, this.mousePoint));
         }
 
         this.isDragging = false;

--- a/src/gov/nasa/worldwind/awt/AbstractViewInputHandler.java
+++ b/src/gov/nasa/worldwind/awt/AbstractViewInputHandler.java
@@ -954,7 +954,7 @@ public abstract class AbstractViewInputHandler implements ViewInputHandler, java
         return slope - 1.0;
     }
 
-    protected static Point constrainToSourceBounds(Point point, Object source)
+    protected static Point constrainToSourceBounds(Point point, WorldWindow source)
     {
         if (point == null)
             return null;
@@ -973,8 +973,10 @@ public abstract class AbstractViewInputHandler implements ViewInputHandler, java
         int y = (int) point.getY();
         if (y < 0)
             y = 0;
-        if (y > c.getHeight())
-            y = c.getHeight();
+        
+        // c.getHeight() is AWT coords height, point is MouseEvent GL surface coords
+        if (y >= source.getView().getViewport().height)
+            y = source.getView().getViewport().height - 1;
 
         return new Point(x, y);
     }

--- a/src/gov/nasa/worldwind/awt/AbstractViewInputHandler.java
+++ b/src/gov/nasa/worldwind/awt/AbstractViewInputHandler.java
@@ -962,21 +962,24 @@ public abstract class AbstractViewInputHandler implements ViewInputHandler, java
         if (!(source instanceof Component))
             return point;
 
-        Component c = (Component) source;
+        // source.getHeight(), source.getWidth() are AWT coords height, 
+        // but the 'point' is MouseEvent GL surface coords.  
+        // Clamp to GL viewport size.
+        int glWidth = source.getView().getViewport().width;
+        int glHeight = source.getView().getViewport().height;
 
         int x = (int) point.getX();
         if (x < 0)
             x = 0;
-        if (x > c.getWidth())
-            x = c.getWidth();
+        if (x >= glWidth)
+            x = glWidth - 1;
 
         int y = (int) point.getY();
         if (y < 0)
             y = 0;
         
-        // c.getHeight() is AWT coords height, point is MouseEvent GL surface coords
-        if (y >= source.getView().getViewport().height)
-            y = source.getView().getViewport().height - 1;
+        if (y >= glHeight)
+            y = glHeight - 1;
 
         return new Point(x, y);
     }

--- a/src/gov/nasa/worldwind/awt/BasicViewInputHandler.java
+++ b/src/gov/nasa/worldwind/awt/BasicViewInputHandler.java
@@ -258,16 +258,16 @@ public abstract class BasicViewInputHandler extends AbstractViewInputHandler
                 return false;
             }
 
+            // 'mouseEvent' is in GL surface coords, (0,0) in lower left of canvas
+            // Make down mouse movement increase the pitch.
             Point movement = ViewUtil.subtract(point, lastPoint);
             int headingInput = movement.x;
-            int pitchInput = movement.y;
+            int pitchInput = -movement.y;
             if (mouseDownPoint == null)
                 mouseDownPoint = lastPoint;
             Point totalMovement = ViewUtil.subtract(point, mouseDownPoint);
             int totalHeadingInput = totalMovement.x;
             int totalPitchInput = totalMovement.y;
-
-
 
             ViewInputAttributes.DeviceAttributes deviceAttributes =
                 getAttributes().getDeviceAttributes(ViewInputAttributes.DEVICE_MOUSE);

--- a/src/gov/nasa/worldwind/awt/BasicViewInputHandler.java
+++ b/src/gov/nasa/worldwind/awt/BasicViewInputHandler.java
@@ -219,10 +219,10 @@ public abstract class BasicViewInputHandler extends AbstractViewInputHandler
 
             Point movement = ViewUtil.subtract(point, lastPoint);
             int headingInput = movement.x;
-            int pitchInput = movement.y;
+            int pitchInput = -movement.y;
             Point totalMovement = ViewUtil.subtract(point, mouseDownPoint);
             int totalHeadingInput = totalMovement.x;
-            int totalPitchInput = totalMovement.y;
+            int totalPitchInput = -totalMovement.y;
 
             ViewInputAttributes.DeviceAttributes deviceAttributes =
                 getAttributes().getDeviceAttributes(ViewInputAttributes.DEVICE_MOUSE);
@@ -267,7 +267,7 @@ public abstract class BasicViewInputHandler extends AbstractViewInputHandler
                 mouseDownPoint = lastPoint;
             Point totalMovement = ViewUtil.subtract(point, mouseDownPoint);
             int totalHeadingInput = totalMovement.x;
-            int totalPitchInput = totalMovement.y;
+            int totalPitchInput = -totalMovement.y;
 
             ViewInputAttributes.DeviceAttributes deviceAttributes =
                 getAttributes().getDeviceAttributes(ViewInputAttributes.DEVICE_MOUSE);

--- a/src/gov/nasa/worldwind/drag/DragContext.java
+++ b/src/gov/nasa/worldwind/drag/DragContext.java
@@ -41,16 +41,16 @@ import java.awt.*;
 public class DragContext
 {
     /**
-     * In accordance with the AWT screen coordinates the top left point of the window is the origin.
+     * In accordance with the GL surface coordinates the top left point of the window is the origin.
      */
     protected Point point;
     /**
-     * In accordance with the AWT screen coordinates the top left point of the window is the origin. This point is the
+     * In accordance with the GL surface coordinates the top left point of the window is the origin. This point is the
      * previous screen point.
      */
     protected Point previousPoint;
     /**
-     * In accordance with the AWT screen coordinates the top left point of the window is the origin. This point refers
+     * In accordance with the GL surface coordinates the top left point of the window is the origin. This point refers
      * to the initial point of the drag event.
      */
     protected Point initialPoint;
@@ -81,9 +81,9 @@ public class DragContext
     }
 
     /**
-     * Returns the current screen point with the origin at the top left corner of the window.
+     * Returns the current GL surface point with the origin at the top left corner of the window.
      *
-     * @return the current screen point.
+     * @return the current GL surface point.
      */
     public Point getPoint()
     {
@@ -91,9 +91,9 @@ public class DragContext
     }
 
     /**
-     * Set the {@link DragContext} current screen point.
+     * Set the {@link DragContext} current GL surface point.
      *
-     * @param point the point to assign to the current screen point.
+     * @param point the point to assign to the current GL surface point.
      *
      * @throws IllegalArgumentException if the point is null.
      */
@@ -110,7 +110,7 @@ public class DragContext
     }
 
     /**
-     * Returns the previous screen point with the origin at the top left corner of the window.
+     * Returns the previous GL surface point with the origin at the top left corner of the window.
      *
      * @return the previous point.
      */
@@ -120,9 +120,9 @@ public class DragContext
     }
 
     /**
-     * Set the {@link DragContext} previous screen point.
+     * Set the {@link DragContext} previous GL surface point.
      *
-     * @param previousPoint the screen point to assign to the previous screen point.
+     * @param previousPoint the GL surface point to assign to the previous screen point.
      *
      * @throws IllegalArgumentException if the previousPoint is null.
      */
@@ -139,10 +139,10 @@ public class DragContext
     }
 
     /**
-     * Returns the initial screen point with the origin at the top left corner of the window. The initial point is the
-     * screen point at the initiation of the drag event.
+     * Returns the initial GL surface point with the origin at the top left corner of the window. The initial point is the
+     * GL surface point at the initiation of the drag event.
      *
-     * @return the initial screen point.
+     * @return the initial GL surface point.
      */
     public Point getInitialPoint()
     {
@@ -150,9 +150,9 @@ public class DragContext
     }
 
     /**
-     * Set the {@link DragContext} initial screen point.
+     * Set the {@link DragContext} initial GL surface point.
      *
-     * @param initialPoint the screen point to assign to the initial screen point.
+     * @param initialPoint the GL surface point to assign to the initial screen point.
      *
      * @throws IllegalArgumentException if the initialPoint is null.
      */

--- a/src/gov/nasa/worldwind/drag/DraggableSupport.java
+++ b/src/gov/nasa/worldwind/drag/DraggableSupport.java
@@ -428,9 +428,7 @@ public class DraggableSupport
 
         Vec4 screenPointOffset = new Vec4(
             dragContext.getInitialPoint().getX() - dragObjectScreenPoint.getX(),
-            dragContext.getInitialPoint().getY() - (
-                dragContext.getView().getViewport().getHeight()
-                    - dragObjectScreenPoint.getY() - 1.0)
+            dragContext.getInitialPoint().getY() - dragObjectScreenPoint.getY()
         );
 
         return screenPointOffset;

--- a/src/gov/nasa/worldwind/event/DragSelectEvent.java
+++ b/src/gov/nasa/worldwind/event/DragSelectEvent.java
@@ -42,10 +42,11 @@ public class DragSelectEvent extends SelectEvent
 {
     private final java.awt.Point previousPickPoint;
 
-    public DragSelectEvent(Object source, String eventAction, MouseEvent mouseEvent, PickedObjectList pickedObjects,
-        java.awt.Point previousPickPoint)
+    public DragSelectEvent(Object source, String eventAction, java.awt.Point awtPt, MouseEvent mouseEvent, 
+    		               PickedObjectList pickedObjects,
+    		               java.awt.Point previousPickPoint)
     {
-        super(source, eventAction, mouseEvent, pickedObjects);
+        super(source, eventAction, awtPt, mouseEvent, pickedObjects);
         this.previousPickPoint = previousPickPoint;
     }
 

--- a/src/gov/nasa/worldwind/event/SelectEvent.java
+++ b/src/gov/nasa/worldwind/event/SelectEvent.java
@@ -104,15 +104,17 @@ public class SelectEvent extends WWEvent
     private final Point pickPoint;			// GL surface coordinates
     private final Rectangle pickRect;		// GL surface coordinates
     private final MouseEvent mouseEvent;	// GL surface coordinates
+    private final Point awtMousePt;			// AWT screen coordinates
     private final PickedObjectList pickedObjects;
 
-    public SelectEvent(Object source, String eventAction, MouseEvent mouseEvent, PickedObjectList pickedObjects)
+    public SelectEvent(Object source, String eventAction, Point awtPt, MouseEvent mouseEvent, PickedObjectList pickedObjects)
     {
         super(source);
         this.eventAction = eventAction;
         this.pickPoint = mouseEvent != null ? mouseEvent.getPoint() : null;
         this.pickRect = null;
         this.mouseEvent = mouseEvent;
+        this.awtMousePt = awtPt;
         this.pickedObjects = pickedObjects;
     }
 
@@ -123,6 +125,7 @@ public class SelectEvent extends WWEvent
         this.pickPoint = pickPoint;
         this.pickRect = null;
         this.mouseEvent = null;
+        this.awtMousePt = null;
         this.pickedObjects = pickedObjects;
     }
 
@@ -133,6 +136,7 @@ public class SelectEvent extends WWEvent
         this.pickPoint = null;
         this.pickRect = pickRectangle;
         this.mouseEvent = null;
+        this.awtMousePt = null;
         this.pickedObjects = pickedObjects;
     }
 
@@ -149,6 +153,10 @@ public class SelectEvent extends WWEvent
     {
         return this.eventAction != null ? this.eventAction : "gov.nasa.worldwind.SelectEvent.UnknownEventAction";
     }
+
+    public Point getAwtMousePt() {
+		return awtMousePt;
+	}
 
     public Point getPickPoint()
     {

--- a/src/gov/nasa/worldwind/render/DrawContext.java
+++ b/src/gov/nasa/worldwind/render/DrawContext.java
@@ -1051,4 +1051,11 @@ public interface DrawContext extends WWObject, Disposable
      * Convert AWT effective screen location to GL surface location using DPI scaling.
      */
     int [] awtPointToGLpoint(Point pt);
+    
+    /**
+     * Convert GL surface coordinate point to AWT device point using DPI scaling.
+     * @param glPoint
+     * @return
+     */
+    public Point glPointToAwtPoint(Point glPoint);
 }

--- a/src/gov/nasa/worldwind/render/DrawContextImpl.java
+++ b/src/gov/nasa/worldwind/render/DrawContextImpl.java
@@ -1752,7 +1752,17 @@ public class DrawContextImpl extends WWObjectImpl implements DrawContext
 		// Convert to GL surface coordinates
 		int [] glSurfacePt = drawable.getNativeSurface().convertToPixelUnits(awtPt);
 		int glSurfaceHeight = drawable.getSurfaceHeight();
-		glSurfacePt[1] = glSurfaceHeight - glSurfacePt[1] - 1;
+		glSurfacePt[1] = glSurfaceHeight-1 - glSurfacePt[1];
 		return glSurfacePt;
 	}
+	    
+    public Point glPointToAwtPoint(Point glPoint) {
+		GLDrawable drawable = glContext.getGLDrawable();
+		if (drawable == null) return glPoint;
+
+		final int viewportHeight = getView().getViewport().height;
+		int [] glPt = { glPoint.x, viewportHeight-1 - glPoint.y };
+        getGLDrawable().getNativeSurface().convertToWindowUnits(glPt);
+        return new Point(glPt[0], glPt[1]);    	
+    }
 }

--- a/src/gov/nasa/worldwind/render/ScreenImage.java
+++ b/src/gov/nasa/worldwind/render/ScreenImage.java
@@ -78,13 +78,6 @@ public class ScreenImage extends WWObjectImpl implements Renderable, Exportable
      * is computed in <code>computeOffsets</code> and used in <code>draw</code> Initially <code>null</code>.
      */
     protected Point screenLocation;
-    /**
-     * Indicates the location of this screen image in the viewport (on the screen) in AWT coordinates. This property is
-     * assigned in <code>setScreenLocation</code> and <code>computeOffsets</code>. In <code>computeOffsets</code>, this
-     * is computed by converting the <code>screenLocation</code> from OpenGL coordinates to AWT coordinates. Initially
-     * <code>null</code>.
-     */
-    protected Point awtScreenLocation;
     protected double dx;
     protected double dy;
     protected Layer pickLayer;
@@ -122,7 +115,7 @@ public class ScreenImage extends WWObjectImpl implements Renderable, Exportable
      */
     public Point getScreenLocation()
     {
-        return this.awtScreenLocation;
+        return this.screenLocation;
     }
 
     /**
@@ -136,7 +129,7 @@ public class ScreenImage extends WWObjectImpl implements Renderable, Exportable
     public Point getScreenLocation(DrawContext dc)
     {
         this.computeOffsets(dc);
-        return this.awtScreenLocation;
+        return this.screenLocation;
     }
 
     /**
@@ -151,17 +144,16 @@ public class ScreenImage extends WWObjectImpl implements Renderable, Exportable
      */
     public void setScreenLocation(Point screenLocation)
     {
-        // Use units PIXELS for the X screen offset, and and INSET_PIXELS for the Y screen offset. The Offset is in
-        // OpenGL coordinates with the origin in the lower-left corner, but the Point is in AWT coordinates with the
-        // origin in the upper-left corner. This offset translates the origin from the lower-left to the upper-left
-        // corner.
-        this.screenOffset = new Offset(screenLocation.getX(), screenLocation.getY(), AVKey.PIXELS, AVKey.INSET_PIXELS);
+        // Use units PIXELS for the X screen offset, and and PIXELS for the Y screen offset. The Offset is in
+        // OpenGL coordinates with the origin in the lower-left corner, as is the Point.  This offset 
+    	// translates the origin from the lower-left to the upper-left corner.
+        this.screenOffset = new Offset(screenLocation.getX(), screenLocation.getY(), AVKey.PIXELS, AVKey.PIXELS);
         this.imageOffset = new Offset(0.5, 0.5, AVKey.FRACTION, AVKey.FRACTION);
 
         // Set cached screen location to the initial screen location so that it can be retrieved if getScreenLocation()
         // is called before the image is rendered. This maintains backward compatibility with the previous behavior of
         // ScreenImage.
-        this.awtScreenLocation = new Point(screenLocation);
+        this.screenLocation = new Point(screenLocation);
     }
 
     /**
@@ -544,12 +536,7 @@ public class ScreenImage extends WWObjectImpl implements Renderable, Exportable
             {
                 this.screenLocation = new Point(viewportWidth / 2, viewportHeight / 2);
             }
-
-            // Convert the screen location from OpenGL to AWT coordinates and store the result in awtScreenLocation. The
-            // awtScreenLocation property is used in getScreenLocation to indicate the screen location in AWT
-            // coordinates.
-            this.awtScreenLocation = new Point(this.screenLocation.x, viewportHeight - this.screenLocation.y);
-
+          
             Point.Double overlayPoint;
             if (this.imageOffset != null)
                 overlayPoint = this.imageOffset.computeOffset(this.width, this.height, null, null);

--- a/src/gov/nasa/worldwindx/examples/ContextMenusOnShapes.java
+++ b/src/gov/nasa/worldwindx/examples/ContextMenusOnShapes.java
@@ -72,7 +72,6 @@ public class ContextMenusOnShapes extends ApplicationTemplate {
             }
         }
 
-        @SuppressWarnings({"UnusedDeclaration"})
         protected void highlight(SelectEvent event, Object o) {
             if (this.lastPickedPlacemark == o) {
                 return; // same thing selected
@@ -110,7 +109,7 @@ public class ContextMenusOnShapes extends ApplicationTemplate {
                 }
 
                 ContextMenu menu = new ContextMenu((Component) event.getSource(), menuInfo);
-                menu.show(event.getMouseEvent());
+                menu.show(event.getAwtMousePt());
             }
         }
     }
@@ -145,7 +144,7 @@ public class ContextMenusOnShapes extends ApplicationTemplate {
             }
         }
 
-        public void show(final MouseEvent event) {
+        public void show(final Point screenPt) {
             JPopupMenu popup = new JPopupMenu();
 
             popup.add(this.menuTitleItem);
@@ -156,7 +155,7 @@ public class ContextMenusOnShapes extends ApplicationTemplate {
                 popup.add(subMenu);
             }
 
-            popup.show(sourceComponent, event.getX(), event.getY());
+            popup.show(sourceComponent, (int)screenPt.getX(), (int)screenPt.getY());
         }
     }
 


### PR DESCRIPTION
**Note:** Filling out this template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the
maintainer's discretion.

### Description of the Change
Make the AWT screen coordinates available in SelectEvent.  This might be needed to display some AWT widget at/near the screen location of a mouse event.  The example program "ContextMenusOnShapes" needs the screen coordinate available to display the context menu at the mouse click location.

### Why Should This Be In Core?
Bug reported by [thwe74](https://github.com/thwe74); see https://github.com/NASAWorldWind/WorldWindJava/pull/262#issuecomment-1787981190.  The example program "ContextMenusOnShapes" wasn't displaying the context menu in the right place on the screen.

Changes for DPI scaling replaced the MouseEvent coordinates with GL surface coordinates.  That example program expects to have the AWT screen coordinates available.

### Benefits
Makes the AWT screen coordinates available in the SelectEvent

### Potential Drawbacks

### Applicable Issues